### PR TITLE
Fix List Records command and add test

### DIFF
--- a/lib/dnsimple/commands/list_records.rb
+++ b/lib/dnsimple/commands/list_records.rb
@@ -1,15 +1,19 @@
+require 'dnsimple/command'
+
 module DNSimple
   module Commands
-    class ListRecords
+    class ListRecords < Command
       def execute(args, options={})
         domain_name = args.shift
-        records = Record.all(domain_name)
-        puts "Found #{records.length} records for #{domain_name}"
+
+        records = Record.all(DNSimple::Domain.new(:name => domain_name))
+
+        say "Found #{records.length} records for #{domain_name}"
         records.each do |record|
           extra = ["ttl:#{record.ttl}", "id:#{record.id}"]
           extra << "prio:#{record.prio}" if record.record_type == "MX"
           extra = "(#{extra.join(', ')})"
-          puts "\t#{record.name}.#{record.domain.name} (#{record.record_type})-> #{record.content} #{extra}"
+          say "\t#{record.name}.#{record.domain.name} (#{record.record_type})-> #{record.content} #{extra}"
         end
       end
     end

--- a/spec/commands/list_records_spec.rb
+++ b/spec/commands/list_records_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'dnsimple/commands/list_records'
+
+describe DNSimple::Commands::ListRecords do
+  before do
+    DNSimple::Record.expects(:all).with(instance_of(DNSimple::Domain)).returns(records)
+  end
+
+  let(:records) { [ record ] }
+  let(:record) { stub(:ttl => ttl, :id => id, :record_type => record_type, :name => name, :domain => domain, :content => content) }
+
+  let(:ttl) { 'ttl' }
+  let(:id) { 'id' }
+  let(:record_type) { 'A' }
+  let(:name) { 'name' }
+  let(:content) { 'content' }
+
+  let(:args) { [ domain_name ] }
+  let(:domain_name) { 'example.com' }
+  let(:domain) { DNSimple::Domain.new(:name => domain_name) }
+  let(:out) { StringIO.new }
+
+  it 'should retrieve all records and print them' do
+    described_class.new(out).execute(args)
+
+    out.string.should include(ttl)
+    out.string.should include(id)
+    out.string.should include(record_type)
+    out.string.should include(name)
+    out.string.should include(domain_name)
+    out.string.should include(content)
+  end
+end
+


### PR DESCRIPTION
The List Records command was broken, as it was not sending a `DNSimple::Domain` instance to `Records.all`. I fixed this, made the class subclass `DNSimple::Command` to work like other commands, and added a simple spec to ensure basic data was being printed. The tests will need some additional cleanup, and a Cucumber feature will eventually need to be added, but the command works for me now.
