### PR TITLE
Fix UpdateRecord

### DIFF
--- a/lib/dnsimple/commands/update_record.rb
+++ b/lib/dnsimple/commands/update_record.rb
@@ -11,7 +11,7 @@ module DNSimple
         end
 
         domain = Domain.find(domain_name)
-        record = Record.find(domain.name, id)
+        record = Record.find(domain, id)
         attributes.each do |name, value|
           record.send("#{name}=", value)
         end


### PR DESCRIPTION
When attempting to run:
dnsimple record:update mydomain.com 12345 ttl:600

was throwing:
lib/dnsimple/record.rb:95:in `find': undefined method`name' for "mydomain.com":String (NoMethodError)

because Record.find assumes a Domain will be passed in, not a string.
