### PR TITLE
Errors in domain operations result in "wrong number of arguments (2 for 1) (ArgumentError)"

### DIFF
--- a/lib/dnsimple/domain.rb
+++ b/lib/dnsimple/domain.rb
@@ -146,7 +146,7 @@ module DNSimple #:nodoc:
       when 401
         raise RuntimeError, "Authentication failed"
       else
-        raise DNSimple::Error.new(name, response["errors"])
+        raise DNSimple::DomainError.new(name, response["errors"])
       end
     end
 
@@ -175,7 +175,7 @@ module DNSimple #:nodoc:
       when 401
         raise RuntimeError, "Authentication failed"
       else
-        raise DNSimple::Error.new(name, response["errors"])
+        raise DNSimple::DomainError.new(name, response["errors"])
       end
     end
 
@@ -195,7 +195,7 @@ module DNSimple #:nodoc:
       when 404
         raise RuntimeError, "Could not find domain #{id_or_name}"
       else
-        raise DNSimple::Error.new(id_or_name, response["errors"])
+        raise DNSimple::DomainError.new(id_or_name, response["errors"])
       end
     end
 


### PR DESCRIPTION
I've updated the errors returned from domain operations to be DNSimple::DomainError instead of the generic DNSimple::Error
