### PR TITLE
Update Readme files to have the latest version's Rdoc link.

### DIFF
--- a/README
+++ b/README
@@ -105,4 +105,4 @@ Sample:
 
 The complete RDoc for the wrapper classes can be found here: 
 
-  http://rdoc.info/projects/aetrion/dnsimple-ruby
+  http://rubydoc.info/gems/dnsimple-ruby/1.2.6/

--- a/README.rdoc
+++ b/README.rdoc
@@ -105,4 +105,4 @@ Sample:
 
 The complete RDoc for the wrapper classes can be found here: 
 
-http://rdoc.info/projects/aetrion/dnsimple-ruby
+http://rubydoc.info/gems/dnsimple-ruby/1.2.6/

--- a/README.textile
+++ b/README.textile
@@ -135,4 +135,4 @@ Sample:
 
 The complete RDoc for the wrapper classes can be found here: 
 
-  "http://rdoc.info/projects/aetrion/dnsimple-ruby":http://rdoc.info/projects/aetrion/dnsimple-ruby
+  "http://rubydoc.info/gems/dnsimple-ruby/1.2.6/":http://rubydoc.info/gems/dnsimple-ruby/1.2.6/


### PR DESCRIPTION
Hi,

First off, just wanted to say thanks for this helpful gem. It has made my life easier, and has made it simpler for us to manage our DNSimple account from our ruby app. Thank you for what you've done here. :-)

Second, just wanted to let you know that the Rdoc link at the bottom of the readme is not up to date. The link contained in it is: http://rdoc.info/projects/aetrion/dnsimple-ruby. I believe the most up to date readme can be found at: http://rubydoc.info/gems/dnsimple-ruby/1.2.6/.

I hope this helps.

--Aaron
