### PR TITLE
fixed bug on base_uri setter in DNSimple::Client

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -36,7 +36,7 @@ class DNSimple::Client
   end
 
   def self.base_uri=(base_uri)
-    base_uri += '/' if base_uri[/\/$/].nil?
+    base_uri += '/' if base_uri && base_uri[/\/$/].nil?
     @base_uri = base_uri
   end
 


### PR DESCRIPTION
Hi,

In client.rb, there is a bug on the base_uri setter.
The cli blows up because it tries to deference the base_uri, which is nil.
Its a simple change.
From :
base_uri += '/' if base_uri[/\/$/].nil?

To:
base_uri += '/' if base_uri && base_uri[/\/$/].nil?

Cheers,
Ben
