### PR TITLE
Add logging around HTTP requests

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -117,10 +117,12 @@ class DNSimple::Client
   end
 
   def self.request(method, path, options)
+    pp [:request, method, path, options] if debug?
+
     response = HTTParty.send(method, "#{base_uri}#{path}",
       standard_options.merge(options))
 
-    pp response if debug?
+    pp [:response, response] if debug?
 
     if response.code == 401
       raise DNSimple::AuthenticationFailed, 'Authentication failed'


### PR DESCRIPTION
I could not get the specs running. 

```
     FakeWeb::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET https://username:password@test.dnsimple.com/users/me.json.  You can use VCR to automatically record this request and replay it later.  For more details, visit the VCR documentation at: http://relishapp.com/myronmarston/vcr/v/1-11-3
```
