### PR TITLE
Domain can auto_renew itself

### DIFF
--- a/lib/dnsimple/domain.rb
+++ b/lib/dnsimple/domain.rb
@@ -19,6 +19,9 @@ module DNSimple
     # When the domain is due to expire
     attr_accessor :expires_on
 
+    # Whether the domain has auto_renew enabled/disabled
+    attr_accessor :auto_renew
+
     # Check the availability of a name
     def self.check(name, options={})
       response = DNSimple::Client.get("/v1/domains/#{name}/check", options)
@@ -99,6 +102,17 @@ module DNSimple
       end
     end
 
+    # Enable auto_renew on the domain
+    def enable_auto_renew
+      return if auto_renew
+      auto_renew!(:post)
+    end
+
+    # Disable auto_renew on the domain
+    def disable_auto_renew
+      return unless auto_renew
+      auto_renew!(:delete)
+    end
 
     # Delete the domain from DNSimple. WARNING: this cannot
     # be undone.
@@ -171,5 +185,16 @@ module DNSimple
       end
     end
 
+    private
+
+    def auto_renew!(method)
+      response = DNSimple::Client.send(method, "/v1/domains/#{name}/auto_renewal")
+      case response.code
+      when 200
+        self.auto_renew = response['domain']['auto_renew']
+      else
+        raise RequestError.new("Error setting auto_renew", response)
+      end
+    end
   end
 end

--- a/spec/dnsimple/domain_spec.rb
+++ b/spec/dnsimple/domain_spec.rb
@@ -33,4 +33,103 @@ describe DNSimple::Domain do
     end
   end
 
+  describe "#enable_auto_renew" do
+
+    context "when response is not 200" do
+
+      let(:domain) { described_class.new 'name' => 'test1383931357.com' }
+      before do
+        stub_request(:post, %r[/v1/domains/test1383931357.com/auto_renewal]).
+          to_return(read_fixture("domains/show/notfound.http"))
+      end
+
+      it "raises a RequestError" do
+        expect { domain.enable_auto_renew }.to raise_error DNSimple::RequestError
+      end
+    end
+
+    context "when auto_renew is true" do
+
+      let(:domain) { described_class.new 'auto_renew' => true,
+                                         'name' => 'example.com' }
+
+      it "does not send a web request" do
+        domain.enable_auto_renew
+        WebMock.should_not have_requested(:post, %r[/v1/domains/example.com/auto_renewal])
+      end
+
+    end
+
+    context "when auto_renew is false" do
+
+      let(:domain) { described_class.new 'auto_renew' => false,
+                                         'name' => 'example.com' }
+      before do
+        stub_request(:post, %r[/v1/domains/example.com/auto_renewal]).
+          to_return(read_fixture("domains/show/success.http"))
+      end
+
+      it "builds the correct request to enable auto_renew" do
+        domain.enable_auto_renew
+
+        WebMock.should have_requested(:post, "https://#{CONFIG['username']}:#{CONFIG['password']}@#{CONFIG['host']}/v1/domains/example.com/auto_renewal").
+          with(:headers => { 'Accept' => 'application/json' })
+      end
+
+      it "sets auto_renew to true on the domain" do
+        domain.enable_auto_renew
+        domain.auto_renew.should be_true
+      end
+    end
+
+  end
+
+  describe "#disable_auto_renew" do
+
+    context "when response is not 200" do
+
+      let(:domain) { described_class.new 'auto_renew' => true,
+                                         'name' => 'test1383931357.com' }
+      before do
+        stub_request(:delete, %r[/v1/domains/test1383931357.com/auto_renewal]).
+          to_return(read_fixture("domains/show/notfound.http"))
+      end
+
+      it "raises a RequestError" do
+        expect { domain.disable_auto_renew }.to raise_error DNSimple::RequestError
+      end
+    end
+
+    context "when auto_renew is true" do
+
+      let(:domain) { described_class.new 'auto_renew' => true,
+                                         'name' => 'example.com' }
+      before do
+        stub_request(:delete, %r[/v1/domains/example.com/auto_renewal]).
+          to_return(read_fixture("domains/show/auto_renew_false.http"))
+      end
+
+      it "builds the correct request to disable auto_renew" do
+        domain.disable_auto_renew
+
+        WebMock.should have_requested(:delete, "https://#{CONFIG['username']}:#{CONFIG['password']}@#{CONFIG['host']}/v1/domains/example.com/auto_renewal").
+          with(:headers => { 'Accept' => 'application/json' })
+      end
+
+      it "sets auto_renew to false on the domain" do
+        domain.disable_auto_renew
+        domain.auto_renew.should be_false
+      end
+    end
+
+    context "when auto_renew is false" do
+      let(:domain) { described_class.new 'auto_renew' => false,
+                                         'name' => 'example.com' }
+
+      it "does not send a web request" do
+        domain.disable_auto_renew
+        WebMock.should_not have_requested(:delete, %r[/v1/domains/example.com/auto_renewal])
+      end
+    end
+  end
 end

--- a/spec/files/domains/show/auto_renew_false.http
+++ b/spec/files/domains/show/auto_renew_false.http
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Server: nginx/1.4.4
+Date: Tue, 14 Jan 2014 19:03:37 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: close
+Status: 200 OK
+X-DNSimple-API-Version: 1.0.0
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Headers: Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with
+Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "3f9496912d04f422c7f083b93bd6e9e3"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: eec6552de5a2aa5ae570139b388ffb9b
+X-Runtime: 0.046892
+Strict-Transport-Security: max-age=315360000
+
+{"domain":{"id":6,"user_id":2,"registrant_id":2,"name":"test-1383931357.com","unicode_name":"test-1383931357.com","token":"5b70de8be5cc783c77aa7d8359abd264","state":"registered","language":null,"lockable":true,"auto_renew":false,"whois_protected":false,"record_count":7,"service_count":0,"expires_on":"2015-11-08","created_at":"2013-11-08T17:22:48Z","updated_at":"2014-01-14T18:27:04Z","parsed_expiration_date":"2015-11-08T17:23:00Z","expires_at":"11/8/2015 5:23:00 PM","name_server_status":null,"private_whois?":false}}


### PR DESCRIPTION
This adds the auto_renew! method which will enable/disable auto_renew based on the whether auto_renew is currently enabled/disabled.

Loosely related to https://github.com/aetrion/dnsimple-ruby/issues/25
