### PR TITLE
Add various missing attributes to the DNSimple::Domain class

### DIFF
--- a/lib/dnsimple/domain.rb
+++ b/lib/dnsimple/domain.rb
@@ -19,6 +19,24 @@ module DNSimple
     # When the domain is due to expire
     attr_accessor :expires_on
 
+    # The state of the domain in DNSimple
+    attr_accessor :state
+
+    # ID of the registrant in DNSimple
+    attr_accessor :registrant_id
+
+    # User ID in DNSimple
+    attr_accessor :user_id
+    
+    # Is the domain lockable
+    attr_accessor :lockable
+    
+    # Is the domain set to autorenew
+    attr_accessor :auto_renew
+    
+    # IS the whois information protected
+    attr_accessor :whois_protected
+
     # Check the availability of a name
     def self.check(name, options={})
       response = DNSimple::Client.get("/v1/domains/#{name}/check", options)

--- a/spec/dnsimple/domain_spec.rb
+++ b/spec/dnsimple/domain_spec.rb
@@ -27,6 +27,12 @@ describe DNSimple::Domain do
         expect(result.expires_on).to eq('2015-11-08')
         expect(result.created_at).to eq("2013-11-08T17:22:48Z")
         expect(result.updated_at).to eq("2014-01-14T18:27:04Z")
+        expect(result.state).to eq("registered")
+        expect(result.registrant_id).to eq(2)
+        expect(result.user_id).to eq(2)
+        expect(result.lockable).to eq(true)
+        expect(result.auto_renew).to eq(true)
+        expect(result.whois_protected).to eq(false)
 
         expect(result.name_server_status).to be_nil
       end


### PR DESCRIPTION
Attributes state, registrant_id, user_id, lockable, auto_renew and whois_protected added to domain
