### PR TITLE
Show correct information in case of an error

### DIFF
--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -11,7 +11,8 @@ module DNSimple
 
   class RequestError < Error
     def initialize(description, response)
-      super("#{description}: #{response["errors"]}")
+      error = response["errors"].size > 0 ? response["errors"] : response["warning"]
+      super("#{description}: #{error} (#{response.code})")
     end
   end
 


### PR DESCRIPTION
Hi, I've noticed that if you hit an error with the API you don't get back the error message.
This is because the code is looking at the wrong field; `error` instead of `errors`.

I've changed this to use the correct field and to show warnings and response codes also.
