### PR TITLE
add support for domain api token

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -7,6 +7,7 @@ module DNSimple
     DEFAULT_BASE_URI = "https://api.dnsimple.com/"
     HEADER_2FA_STRICT = "X-DNSimple-2FA-Strict"
     HEADER_API_TOKEN = "X-DNSimple-Token"
+    HEADER_DOMAIN_API_TOKEN = "X-DNSimple-Domain-Token"
     HEADER_OTP_TOKEN = "X-DNSimple-OTP"
     HEADER_EXCHANGE_TOKEN = "X-DNSimple-OTP-Token"
 
@@ -15,7 +16,7 @@ module DNSimple
       #   Defaults to false.
       attr_accessor :debug
 
-      attr_accessor :username, :password, :exchange_token, :api_token
+      attr_accessor :username, :password, :exchange_token, :api_token, :domain_api_token
     end
 
     # Gets the qualified API base uri.
@@ -51,6 +52,7 @@ module DNSimple
         self.password       = credentials['password']
         self.exchange_token = credentials['exchange_token']
         self.api_token      = credentials['api_token']
+        self.domain_api_token = credentials['domain_api_token']
         self.base_uri       = credentials['site']       if credentials['site']
         self.base_uri       = credentials['base_uri']   if credentials['base_uri']
         @http_proxy = { :addr => credentials['proxy_addr'], :port => credentials['proxy_port'] } if credentials['proxy_addr'] || credentials['proxy_port']
@@ -63,7 +65,7 @@ module DNSimple
     end
 
     def self.credentials_loaded?
-      (@credentials_loaded ||= false) or (username and (password or api_token))
+      (@credentials_loaded ||= false) or domain_api_token or (username and (password or api_token))
     end
 
     def self.base_options
@@ -83,6 +85,8 @@ module DNSimple
         options[:basic_auth] = { :username => exchange_token, :password => "x-2fa-basic" }
       elsif password
         options[:basic_auth] = { :username => username, :password => password }
+      elsif domain_api_token
+        options[:headers][HEADER_DOMAIN_API_TOKEN] = domain_api_token
       elsif api_token
         options[:headers][HEADER_API_TOKEN] = "#{username}:#{api_token}"
       else

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -30,7 +30,7 @@ describe DNSimple::Client do
 
   describe ".request" do
     before do
-      [:username, :password, :exchange_token, :api_token].each do |attribute|
+      [:username, :password, :exchange_token, :api_token, :domain_api_token].each do |attribute|
         described_class.send("#{attribute}=", nil)
       end
     end
@@ -42,6 +42,17 @@ describe DNSimple::Client do
 
       HTTParty.expects(:get).
         with('https://api.example.com/domains', has_entries(:basic_auth => { :username => 'user', :password => 'pass' })).
+        returns(response)
+
+      described_class.request(:get, '/domains', {})
+    end
+
+    it "uses header authentication if there's a domain api token provided" do
+      described_class.domain_api_token  = 'domaintoken'
+      described_class.base_uri   = 'https://api.example.com/'
+
+      HTTParty.expects(:get).
+        with('https://api.example.com/domains', has_entries(:headers => has_entries({ 'X-DNSimple-Domain-Token' => 'domaintoken' }))).
         returns(response)
 
       described_class.request(:get, '/domains', {})


### PR DESCRIPTION
With the upcoming change to the api we need to use domain api tokens to authenticate from chef. This is a simple change that adds this via the `domain_api_token` attribute. Thanks!
