### PR TITLE
Update API token docs because username is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ user = DNSimple::User.me
 #### API Token
 
 ```ruby
+DNSimple::Client.username = 'YOUR_USERNAME'
 DNSimple::Client.api_token = 'the-token'
 
 user = DNSimple::User.me


### PR DESCRIPTION
Calls with token fail when username is not present
