### PR TITLE
Swap template_id and domain_id arguments

### DIFF
--- a/lib/dnsimple/client/templates.rb
+++ b/lib/dnsimple/client/templates.rb
@@ -154,14 +154,14 @@ module Dnsimple
       #   client.templates.apply_template(1010, "example.com", 5401)
       #
       # @param  [Fixnum] account_id The account ID
-      # @param  [#to_s] domain_id The Domain ID or name
       # @param  [#to_s] template_id The template ID
+      # @param  [#to_s] domain_id The Domain ID or name
       # @param  [Hash] options
       # @return [Dnsimple::Response<nil>]
       #
       # @raise  [Dnsimple::NotFoundError]
       # @raise  [Dnsimple::RequestError]
-      def apply_template(account_id, domain_id, template_id, options = {})
+      def apply_template(account_id, template_id, domain_id, options = {})
         endpoint = Client.versioned("/%s/domains/%s/templates/%s" % [account_id, domain_id, template_id])
         response = client.post(endpoint, options)
 

--- a/spec/dnsimple/client/templates_spec.rb
+++ b/spec/dnsimple/client/templates_spec.rb
@@ -191,8 +191,8 @@ describe Dnsimple::Client, ".templates" do
 
   describe "#apply_template" do
     let(:account_id)  { 1010 }
-    let(:domain_id)   { 'example.com' }
     let(:template_id) { 5410 }
+    let(:domain_id)   { 'example.com' }
 
     before do
       stub_request(:post, %r{/v2/#{account_id}/domains/#{domain_id}/templates/#{template_id}$}).
@@ -200,14 +200,14 @@ describe Dnsimple::Client, ".templates" do
     end
 
     it "builds the correct request" do
-      subject.apply_template(account_id, domain_id, template_id)
+      subject.apply_template(account_id, template_id, domain_id)
 
       expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/domains/#{domain_id}/templates/#{template_id}").
           with(headers: { "Accept" => "application/json" })
     end
 
     it "returns nil" do
-      response = subject.apply_template(account_id, domain_id, template_id)
+      response = subject.apply_template(account_id, template_id, domain_id)
       expect(response).to be_a(Dnsimple::Response)
       expect(response.data).to be_nil
     end


### PR DESCRIPTION
As discussed [here](https://github.com/dnsimple/dnsimple-go/pull/39#discussion_r71845325) we have decided that the first arguments (`account_id` and `template_id`) represent the resource we are operating with and the later arguments represent the data the resource is operated with (`domain_id`).