### PR TITLE
Update misleading tests

### DIFF
--- a/spec/dnsimple/client/oauth_spec.rb
+++ b/spec/dnsimple/client/oauth_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Dnsimple::Client, ".oauth" do
 
-  subject { described_class.new(base_url: "https://api.dnsimple.test", access_token: "a1b2c3").oauth }
+  subject { described_class.new(base_url: "https://api.dnsimple.test").oauth }
 
 
   describe "#exchange_authorization_for_token" do
     let(:client_id) { "super-client" }
     let(:client_secret) { "super-secret" }
     let(:code) { "super-code" }
+    let(:state) { "super-state" }
 
     before do
       stub_request(:post, %r{/v2/oauth/access_token$}).
@@ -16,15 +17,15 @@ describe Dnsimple::Client, ".oauth" do
     end
 
     it "builds the correct request" do
-      subject.exchange_authorization_for_token(code, client_id, client_secret)
+      subject.exchange_authorization_for_token(code, client_id, client_secret, state: state)
 
       expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/oauth/access_token").
-          with(body: { client_id: client_id, client_secret: client_secret, code: code, grant_type: "authorization_code" }).
+          with(body: { client_id: client_id, client_secret: client_secret, code: code, state: state, grant_type: "authorization_code" }).
           with(headers: { 'Accept' => 'application/json' })
     end
 
     it "returns oauth token" do
-      result = subject.exchange_authorization_for_token(code, client_id, client_secret)
+      result = subject.exchange_authorization_for_token(code, client_id, client_secret, state: state)
 
       expect(result).to be_a(Dnsimple::Struct::OauthToken)
       expect(result.access_token).to eq("zKQ7OLqF5N1gylcJweA9WodA000BUNJD")
@@ -33,7 +34,6 @@ describe Dnsimple::Client, ".oauth" do
     end
 
     context "when state and redirect_uri are provided" do
-      let(:state) { "super-state" }
       let(:redirect_uri) { "super-redirect-uri" }
 
       it "builds the correct request" do


### PR DESCRIPTION
* "access_code" would not be available before OAuth dance completes
* "state" and "redirect_uri" are required when exchanging authorization code for token; the test should always require them