### PR TITLE
Fix dataless DELETE requests

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -183,7 +183,6 @@ module Dnsimple
       request_options = request_options(options)
 
       if data
-        request_options[:headers]["Content-Type"] = content_type(request_options[:headers])
         request_options[:body] = content_data(request_options[:headers], data)
       end
 
@@ -207,6 +206,7 @@ module Dnsimple
           format:   :json,
           headers:  {
               "Accept" => "application/json",
+              "Content-Type" => "application/json",
           },
       }
     end
@@ -244,10 +244,6 @@ module Dnsimple
       else
         "#{Dnsimple::Default::USER_AGENT} #{user_agent}"
       end
-    end
-
-    def content_type(headers)
-      headers["Content-Type"] || "application/json"
     end
 
     def content_data(headers, data)

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -123,7 +123,7 @@ describe Dnsimple::Client do
                   'Accept' => 'application/json',
                   'Content-Type' => 'application/json',
                   'User-Agent' => Dnsimple::Default::USER_AGENT,
-              },
+              }
           )
     end
 
@@ -139,7 +139,7 @@ describe Dnsimple::Client do
                   'Accept' => 'application/json',
                   'Content-Type' => 'application/json',
                   'User-Agent' => Dnsimple::Default::USER_AGENT,
-              },
+              }
           ).
           and_return(double('response', code: 200))
 
@@ -186,7 +186,7 @@ describe Dnsimple::Client do
                   'Accept' => 'application/json',
                   'Content-Type' => 'application/json',
                   'User-Agent' => Dnsimple::Default::USER_AGENT,
-              },
+              }
           ).
           and_return(double('response', code: 200))
 

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -114,11 +114,17 @@ describe Dnsimple::Client do
     it "performs a request" do
       stub_request(:get, %r{/foo})
 
-      subject.request(:get, 'foo', {})
+      subject.request(:get, 'foo')
 
       expect(WebMock).to have_requested(:get, "https://api.dnsimple.com/foo").
-          with(basic_auth: %w(user pass),
-               headers: { 'Accept' => 'application/json', 'User-Agent' => Dnsimple::Default::USER_AGENT })
+          with(
+              basic_auth: %w(user pass),
+              headers: {
+                  'Accept' => 'application/json',
+                  'Content-Type' => 'application/json',
+                  'User-Agent' => Dnsimple::Default::USER_AGENT,
+              },
+          )
     end
 
     it "delegates to HTTParty" do
@@ -129,7 +135,11 @@ describe Dnsimple::Client do
               "#{subject.base_url}foo",
               format: :json,
               basic_auth: { username: "user", password: "pass" },
-              headers: { 'Accept' => 'application/json', 'User-Agent' => Dnsimple::Default::USER_AGENT }
+              headers: {
+                  'Accept' => 'application/json',
+                  'Content-Type' => 'application/json',
+                  'User-Agent' => Dnsimple::Default::USER_AGENT,
+              },
           ).
           and_return(double('response', code: 200))
 
@@ -172,7 +182,11 @@ describe Dnsimple::Client do
               format: :json,
               http_proxyaddr: "example-proxy.com",
               http_proxyport: "4321",
-              headers: { 'Accept' => 'application/json', 'User-Agent' => Dnsimple::Default::USER_AGENT }
+              headers: {
+                  'Accept' => 'application/json',
+                  'Content-Type' => 'application/json',
+                  'User-Agent' => Dnsimple::Default::USER_AGENT,
+              },
           ).
           and_return(double('response', code: 200))
 


### PR DESCRIPTION
When using `client.zones.delete_record(account_id, zone_id, record_id)`,
the following is raised: `Dnsimple::RequestError: Not Acceptable`.

After some testing, it seems like including `headers: { "Content-Type"
=> "application/json" }` as an option to the `delete_record` call solves the problem.

This commit sets the default `"Content-Type"` to `"application/json"`.