### PR TITLE
Update registrar URLs

### DIFF
--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -128,7 +128,7 @@ module Dnsimple
       #
       # @raise  [RequestError] When the request fails.
       def transfer_domain_out(account_id, domain_name, options = {})
-        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer_out" % [account_id, domain_name])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/authorize_transfer_out" % [account_id, domain_name])
         response = client.post(endpoint, nil, options)
 
         Dnsimple::Response.new(response, nil)

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -108,7 +108,7 @@ module Dnsimple
       # @raise  [RequestError] When the request fails.
       def transfer_domain(account_id, domain_name, attributes, options = {})
         Extra.validate_mandatory_attributes(attributes, [:registrant_id])
-        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer" % [account_id, domain_name])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/transfers" % [account_id, domain_name])
         response = client.post(endpoint, attributes, options)
 
         Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -65,7 +65,7 @@ module Dnsimple
       # @raise  [RequestError] When the request fails.
       def register_domain(account_id, domain_name, attributes, options = {})
         Extra.validate_mandatory_attributes(attributes, [:registrant_id])
-        endpoint = Client.versioned("/%s/registrar/domains/%s/registration" % [account_id, domain_name])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/registrations" % [account_id, domain_name])
         response = client.post(endpoint, attributes, options)
 
         Dnsimple::Response.new(response, Struct::DomainRegistration.new(response["data"]))

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -86,7 +86,7 @@ module Dnsimple
       #
       # @raise  [RequestError] When the request fails.
       def renew_domain(account_id, domain_name, attributes = nil, options = {})
-        endpoint = Client.versioned("/%s/registrar/domains/%s/renewal" % [account_id, domain_name])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/renewals" % [account_id, domain_name])
         response = client.post(endpoint, attributes, options)
 
         Dnsimple::Response.new(response, Struct::DomainRenewal.new(response["data"]))

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -84,7 +84,7 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/registration$}).
+      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/registrations$}).
           to_return(read_http_fixture("registerDomain/success.http"))
     end
 
@@ -93,7 +93,7 @@ describe Dnsimple::Client, ".registrar" do
     it "builds the correct request" do
       subject.register_domain(account_id, domain_name = "example.com", attributes)
 
-      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/registration").
+      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/registrations").
           with(body: attributes).
           with(headers: { "Accept" => "application/json" })
     end

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -159,7 +159,7 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfer$}).
+      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfers$}).
           to_return(read_http_fixture("transferDomain/success.http"))
     end
 
@@ -168,7 +168,7 @@ describe Dnsimple::Client, ".registrar" do
     it "builds the correct request" do
       subject.transfer_domain(account_id, domain_name = "example.com", attributes)
 
-      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer").
+      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfers").
           with(body: attributes).
           with(headers: { "Accept" => "application/json" })
     end
@@ -191,7 +191,7 @@ describe Dnsimple::Client, ".registrar" do
 
     context "when the domain is already in DNSimple" do
       it "raises a BadRequestError" do
-        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfer$}).
+        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfers$}).
             to_return(read_http_fixture("transferDomain/error-indnsimple.http"))
 
         expect {
@@ -202,7 +202,7 @@ describe Dnsimple::Client, ".registrar" do
 
     context "when :auth_code wasn't provided and is required by the TLD" do
       it "raises a BadRequestError" do
-        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfer$}).
+        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfers$}).
             to_return(read_http_fixture("transferDomain/error-missing-authcode.http"))
 
         expect {

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -216,14 +216,14 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/transfer_out$}).
+      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/authorize_transfer_out$}).
           to_return(read_http_fixture("transferDomainOut/success.http"))
     end
 
     it "builds the correct request" do
       subject.transfer_domain_out(account_id, domain_name = "example.com")
 
-      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer_out").
+      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/authorize_transfer_out").
           with(headers: { "Accept" => "application/json" })
     end
 

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -119,7 +119,7 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/renewal$}).
+      stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/renewals$}).
           to_return(read_http_fixture("renewDomain/success.http"))
     end
 
@@ -128,7 +128,7 @@ describe Dnsimple::Client, ".registrar" do
     it "builds the correct request" do
       subject.renew_domain(account_id, domain_name = "example.com", attributes)
 
-      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/renewal").
+      expect(WebMock).to have_requested(:post, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/renewals").
           with(body: attributes).
           with(headers: { "Accept" => "application/json" })
     end
@@ -145,7 +145,7 @@ describe Dnsimple::Client, ".registrar" do
 
     context "when it is too soon for the domain to be renewed" do
       it "raises a BadRequestError" do
-        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/renewal$}).
+        stub_request(:post, %r{/v2/#{account_id}/registrar/domains/.+/renewals$}).
             to_return(read_http_fixture("renewDomain/error-tooearly.http"))
 
         expect {


### PR DESCRIPTION
The registrar methods were using our old, URLs that we decided to migrate before API v2 GA.
This PR updates the URLs to the public, [documented](https://developer.dnsimple.com/v2/registrar/) ones.