### PR TITLE
Ensure to work with UTF-8 domain names

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'httparty'
 require 'dnsimple/extra'
 require 'dnsimple/struct'
@@ -66,6 +67,7 @@ module Dnsimple
       end
 
       @services = {}
+      @uri_parser = URI::Parser.new
     end
 
 
@@ -187,7 +189,8 @@ module Dnsimple
         request_options[:body] = content_data(request_options[:headers], data)
       end
 
-      HTTParty.send(method, base_url + path, request_options)
+      url = @uri_parser.escape(base_url + path)
+      HTTParty.send(method, url, request_options)
     end
 
 

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -21,6 +21,13 @@ describe Dnsimple::Client, ".registrar" do
     end
 
     it "works with UTF-8 chars" do
+      subject.check_domain(account_id, domain_name = "dnsimplé.ch")
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/check")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
+    it "works with escaped UTF-8 chars" do
       subject.check_domain(account_id, domain_name = "dnsimpl\u{e9}.ch")
 
       expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/check")

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -20,6 +20,13 @@ describe Dnsimple::Client, ".registrar" do
           .with(headers: { "Accept" => "application/json" })
     end
 
+    it "works with UTF-8 chars" do
+      subject.check_domain(account_id, domain_name = "dnsimpl\u{e9}.ch")
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/check")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
     it "returns the availability" do
       response = subject.check_domain(account_id, "example.com")
       expect(response).to be_a(Dnsimple::Response)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,7 @@ unless defined?(SPEC_ROOT)
 end
 
 Dir[File.join(SPEC_ROOT, "support/**/*.rb")].each { |f| require f }
+
+RSpec.configure do |config|
+  config.warnings = true
+end


### PR DESCRIPTION
Our low level HTTP client (`httparty`) uses to verify if a given URI is valid or not. To do so, it relies on Ruby's stdlib via `URI.parse`. This function only permits ASCII chars, or it raises an `URI::InvalidURIError` exception.

As result, developers using our DNSimple API client can't perform requests with accents in their domain names.

This PR aims to fix the problem, by escaping the **entire URI** before to perform a request.