### PR TITLE
Fixes the examples in the documentation to match the method name

### DIFF
--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -7,7 +7,7 @@ module Dnsimple
       # @see https://developer.dnsimple.com/v2/registrar/#check
       #
       # @example Check whether example.com is available:
-      #   client.registrar.check(1010, "example.com")
+      #   client.registrar.check_domain(1010, "example.com")
       #
       # @param  [Integer] account_id the account ID
       # @param  [#to_s] domain_name the domain name to check
@@ -54,7 +54,7 @@ module Dnsimple
       #
       # @example Initiate the registration of example.com using the contact 1234 as registrant
       #   including WHOIS privacy for the domain and enabling auto renewal:
-      #   client.registrar.register(1010, "example.com", registrant_id: 1234, private_whois: true, auto_renew: true)
+      #   client.registrar.register_domain(1010, "example.com", registrant_id: 1234, private_whois: true, auto_renew: true)
       #
       # @param  [Integer] account_id the account ID
       # @param  [#to_s] domain_name the domain name to register
@@ -76,7 +76,7 @@ module Dnsimple
       # @see https://developer.dnsimple.com/v2/registrar/#renew
       #
       # @example Renew example.com for 3 years:
-      #   client.registrar.renew(1010, "example.com", period: 3)
+      #   client.registrar.renew_domain(1010, "example.com", period: 3)
       #
       # @param  [Integer] account_id the account ID
       # @param  [#to_s] domain_name the domain name to renew
@@ -97,7 +97,7 @@ module Dnsimple
       # @see https://developer.dnsimple.com/v2/registrar/#transfer
       #
       # @example Initiate the transfer for example.com using the contact 1234 as registrant:
-      #   client.registrar.transfer(1010, "example.com", registrant_id: 1234, auth_code: "x1y2z3")
+      #   client.registrar.transfer_domain(1010, "example.com", registrant_id: 1234, auth_code: "x1y2z3")
       #
       # @param  [Integer] account_id the account ID
       # @param  [#to_s] domain_name the domain name to transfer
@@ -119,7 +119,7 @@ module Dnsimple
       # @see https://developer.dnsimple.com/v2/registrar/#transfer-out
       #
       # @example Request to transfer of example.com out of DNSimple:
-      #   client.registrar.transfer_out(1010, "example.com")
+      #   client.registrar.transfer_domain_out(1010, "example.com")
       #
       # @param  [Integer] account_id the account ID
       # @param  [#to_s] domain_name the domain name to transfer out


### PR DESCRIPTION
This PR fixes the example methods in the documentation of the registration module to match the method name.

While browsing http://www.rubydoc.info/gems/dnsimple, I found that the examples provided for the registration were incorrect.

I am not sure how to publish the latest to http://www.rubydoc.info/gems/dnsimple, so I need some help there. 🙏 