### PR TITLE
Implement client methods for Transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 - CHANGED: Minimum Ruby version is now 2.4
 - CHANGED: User-agent format has been changed to prepend custom token before default token.
-
+- NEW: Added `registrar.get_domain_transfer` to retrieve a domain transfer. (dnsimple/dnsimple-ruby#180)
+- NEW: Added `registrar.cancel_domain_transfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-ruby#180)
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 - CHANGED: User-agent format has been changed to prepend custom token before default token.
 - NEW: Added `registrar.get_domain_transfer` to retrieve a domain transfer. (dnsimple/dnsimple-ruby#180)
 - NEW: Added `registrar.cancel_domain_transfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-ruby#180)
+- NEW: Added `DomainTransfer#status_description` attribute to identify the failure reason of a transfer. (dnsimple/dnsimple-ruby#180).
 
 ## 4.6.0
 

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -116,6 +116,50 @@ module Dnsimple
         Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))
       end
 
+      # Retrieves the details of an existing domain transfer.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/#getDomainTransfer
+      #
+      # @example Retrieve the transfer 42 for example.com:
+      #   client.registrar.get_domain_transfer(1010, "example.com", 42)
+      #
+      # @param  [Integer] account_id the account ID
+      # @param  [#to_s] domain_name the domain name
+      # @param  [Integer] domain_transfer_id the domain transfer ID
+      # @param  [Hash] options
+      # @return [Struct::DomainTransfer]
+      #
+      # @raise  [NotFoundError] When record is not found.
+      # @raise  [RequestError]  When the request fails.
+      def get_domain_transfer(account_id, domain_name, domain_transfer_id, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer/%s" % [account_id, domain_name, domain_transfer_id])
+        response = client.get(endpoint, options)
+
+        Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))
+      end
+
+      # Cancels an in progress domain transfer.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer
+      #
+      # @example Cancel the transfer 42 for example.com:
+      #   client.registrar.cancel_domain_transfer(1010, "example.com", 42)
+      #
+      # @param  [Integer] account_id the account ID
+      # @param  [#to_s] domain_name the domain name
+      # @param  [Integer] domain_transfer_id the domain transfer ID
+      # @param  [Hash] options
+      # @return [Struct::DomainTransfer]
+      #
+      # @raise  [NotFoundError] When record is not found.
+      # @raise  [RequestError]  When the request fails.
+      def cancel_domain_transfer(account_id, domain_name, domain_transfer_id, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer/%s" % [account_id, domain_name, domain_transfer_id])
+        response = client.delete(endpoint, options)
+
+        Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))
+      end
+
       # Requests the transfer of a domain out of DNSimple.
       #
       # @see https://developer.dnsimple.com/v2/registrar/#transfer-out

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -132,7 +132,7 @@ module Dnsimple
       # @raise  [NotFoundError] When record is not found.
       # @raise  [RequestError]  When the request fails.
       def get_domain_transfer(account_id, domain_name, domain_transfer_id, options = {})
-        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer/%s" % [account_id, domain_name, domain_transfer_id])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/transfers/%s" % [account_id, domain_name, domain_transfer_id])
         response = client.get(endpoint, options)
 
         Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))
@@ -154,7 +154,7 @@ module Dnsimple
       # @raise  [NotFoundError] When record is not found.
       # @raise  [RequestError]  When the request fails.
       def cancel_domain_transfer(account_id, domain_name, domain_transfer_id, options = {})
-        endpoint = Client.versioned("/%s/registrar/domains/%s/transfer/%s" % [account_id, domain_name, domain_transfer_id])
+        endpoint = Client.versioned("/%s/registrar/domains/%s/transfers/%s" % [account_id, domain_name, domain_transfer_id])
         response = client.delete(endpoint, options)
 
         Dnsimple::Response.new(response, Struct::DomainTransfer.new(response["data"]))

--- a/lib/dnsimple/struct/domain_transfer.rb
+++ b/lib/dnsimple/struct/domain_transfer.rb
@@ -22,7 +22,7 @@ module Dnsimple
       # @return [Bool] True if the domain WHOIS privacy was requested.
       attr_accessor :whois_privacy
 
-      # @return [String] The reason if transfer failed.
+      # @return [String,nil] The reason if transfer failed.
       attr_accessor :status_description
 
       # @return [String] When the domain renewal was created in DNSimple.

--- a/lib/dnsimple/struct/domain_transfer.rb
+++ b/lib/dnsimple/struct/domain_transfer.rb
@@ -22,6 +22,9 @@ module Dnsimple
       # @return [Bool] True if the domain WHOIS privacy was requested.
       attr_accessor :whois_privacy
 
+      # @return [String] The reason if transfer failed.
+      attr_accessor :status_description
+
       # @return [String] When the domain renewal was created in DNSimple.
       attr_accessor :created_at
 

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -214,6 +214,73 @@ describe Dnsimple::Client, ".registrar" do
     end
   end
 
+  describe "#get_transfer_domain" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/transfer/.+$})
+          .to_return(read_http_fixture("getDomainTransfer/success.http"))
+    end
+
+    it "builds the correct request" do
+      subject.get_domain_transfer(account_id, domain_name = "example.com", transfer_id = 42)
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer/#{transfer_id}")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the domain transfer" do
+      response = subject.get_domain_transfer(account_id, "example.com", 42)
+      expect(response).to be_a(Dnsimple::Response)
+
+      result = response.data
+      expect(result).to be_a(Dnsimple::Struct::DomainTransfer)
+      expect(result.id).to eq(42)
+      expect(result.domain_id).to eq(2)
+      expect(result.registrant_id).to eq(3)
+      expect(result.state).to eq("cancelled")
+      expect(result.auto_renew).to be(false)
+      expect(result.whois_privacy).to be(false)
+      expect(result.status_description).to eq("Canceled by customer")
+      expect(result.created_at).to eq("2020-04-27T18:08:44Z")
+      expect(result.updated_at).to eq("2020-04-27T18:20:01Z")
+    end
+  end
+
+  describe "#cancel_domain_transfer" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:delete, %r{/v2/#{account_id}/registrar/domains/.+/transfer/.+$})
+          .to_return(read_http_fixture("cancelDomainTransfer/success.http"))
+    end
+
+    it "builds the correct request" do
+      subject.cancel_domain_transfer(account_id, domain_name = "example.com", transfer_id = 42)
+
+      expect(WebMock).to have_requested(:delete, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer/#{transfer_id}")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the domain transfer" do
+      response = subject.cancel_domain_transfer(account_id, "example.com", 42)
+      expect(response).to be_a(Dnsimple::Response)
+
+      result = response.data
+      expect(result).to be_a(Dnsimple::Struct::DomainTransfer)
+      expect(result.id).to eq(42)
+      expect(result.domain_id).to eq(6)
+      expect(result.registrant_id).to eq(1)
+      expect(result.state).to eq("transferring")
+      expect(result.auto_renew).to be(true)
+      expect(result.whois_privacy).to be(false)
+      expect(result.status_description).to eq(nil)
+      expect(result.created_at).to eq("2020-04-24T19:19:03Z")
+      expect(result.updated_at).to eq("2020-04-24T19:19:15Z")
+    end
+  end
+
+
   describe "#transfer_domain_out" do
     let(:account_id) { 1010 }
 

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -218,14 +218,14 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/transfer/.+$})
+      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/transfers/.+$})
           .to_return(read_http_fixture("getDomainTransfer/success.http"))
     end
 
     it "builds the correct request" do
       subject.get_domain_transfer(account_id, domain_name = "example.com", transfer_id = 42)
 
-      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer/#{transfer_id}")
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfers/#{transfer_id}")
           .with(headers: { "Accept" => "application/json" })
     end
 
@@ -251,14 +251,14 @@ describe Dnsimple::Client, ".registrar" do
     let(:account_id) { 1010 }
 
     before do
-      stub_request(:delete, %r{/v2/#{account_id}/registrar/domains/.+/transfer/.+$})
+      stub_request(:delete, %r{/v2/#{account_id}/registrar/domains/.+/transfers/.+$})
           .to_return(read_http_fixture("cancelDomainTransfer/success.http"))
     end
 
     it "builds the correct request" do
       subject.cancel_domain_transfer(account_id, domain_name = "example.com", transfer_id = 42)
 
-      expect(WebMock).to have_requested(:delete, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfer/#{transfer_id}")
+      expect(WebMock).to have_requested(:delete, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/transfers/#{transfer_id}")
           .with(headers: { "Accept" => "application/json" })
     end
 

--- a/spec/fixtures.http/cancelDomainTransfer/success.http
+++ b/spec/fixtures.http/cancelDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Wed, 29 Apr 2020 19:49:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 202 Accepted
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1588193270
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: no-store, must-revalidate, private, max-age=0
+X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
+X-Runtime: 1.752154
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 6,
+    "registrant_id": 1,
+    "state": "transferring",
+    "auto_renew": true,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": null,
+    "created_at": "2020-04-24T19:19:03Z",
+    "updated_at": "2020-04-24T19:19:15Z"
+  }
+}

--- a/spec/fixtures.http/getDomainTransfer/success.http
+++ b/spec/fixtures.http/getDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Apr 2020 19:40:00 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1588019949
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
+X-Runtime: 0.092854
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 2,
+    "registrant_id": 3,
+    "state": "cancelled",
+    "auto_renew": false,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": "Canceled by customer",
+    "created_at": "2020-04-27T18:08:44Z",
+    "updated_at": "2020-04-27T18:20:01Z"
+  }
+}


### PR DESCRIPTION
This commit introduces two client methods for the new features in
TransferAPI:
- getDomainTransfer - Retrieves the information for a specific domain
transfer
- cancelDomainTransfer - Cancels an in progress domain transfer

It also adds the new status_description field in the DomainTransfer
response.