### PR TITLE
Add missing build step in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,12 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
     git push origin --tags
     ```
 
+1. Build the package.
+
+    ```shell
+    rake build
+    ```
+
 1. Release to RubyGems.
 
     ```shell


### PR DESCRIPTION
CONTRIBUTING file is missing the `rake build` step. This is the step
where the pkg file will be generated.