### PR TITLE
Deprecate Domain `expires_on` in favor of `expires_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
+## master
+
+- CHANGED: `Domain` now have `expires_at` (timestamp) instead of `expires_on` (date only). (dnsimple/dnsimple-ruby#186)
 
 ## 5.0.0
 

--- a/lib/dnsimple/client/domains.rb
+++ b/lib/dnsimple/client/domains.rb
@@ -16,7 +16,7 @@ module Dnsimple
       #   client.domains.list(1010, page: 2)
       #
       # @example List domains, provide a sorting policy
-      #   client.domains.list(1010, sort: "expires_on:asc")
+      #   client.domains.list(1010, sort: "expiration:asc")
       #
       # @example List domains, provide a filtering policy
       #   client.domains.list(1010, filter: { name_like: "example" })

--- a/lib/dnsimple/struct/domain.rb
+++ b/lib/dnsimple/struct/domain.rb
@@ -28,8 +28,8 @@ module Dnsimple
       # @return [Bool] True if the domain WHOIS privacy is enabled, false otherwise.
       attr_accessor :private_whois
 
-      # @return [String] The date the domain will expire.
-      attr_accessor :expires_on
+      # @return [String] The timestamp when domain will expire.
+      attr_accessor :expires_at
 
       # @return [String] When the domain was created in DNSimple.
       attr_accessor :created_at

--- a/spec/dnsimple/client/domains_spec.rb
+++ b/spec/dnsimple/client/domains_spec.rb
@@ -35,9 +35,9 @@ describe Dnsimple::Client, ".domains" do
     end
 
     it "supports sorting" do
-      subject.domains(account_id, sort: "expires_on:asc")
+      subject.domains(account_id, sort: "expiration:asc")
 
-      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/domains?sort=expires_on:asc")
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/domains?sort=expiration:asc")
     end
 
     it "supports filtering" do
@@ -84,9 +84,9 @@ describe Dnsimple::Client, ".domains" do
     end
 
     it "supports sorting" do
-      subject.all_domains(account_id, sort: "expires_on:asc")
+      subject.all_domains(account_id, sort: "expiration:asc")
 
-      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/domains?page=1&per_page=100&sort=expires_on:asc")
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/domains?page=1&per_page=100&sort=expiration:asc")
     end
 
     it "supports filtering" do
@@ -133,28 +133,28 @@ describe Dnsimple::Client, ".domains" do
     end
 
     it "builds the correct request" do
-      subject.domain(account_id, domain = "example.com")
+      subject.domain(account_id, domain = "example-alpha.com")
 
       expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/domains/#{domain}")
           .with(headers: { 'Accept' => 'application/json' })
     end
 
     it "returns the domain" do
-      response = subject.domain(account_id, "example.com")
+      response = subject.domain(account_id, "example-alpha.com")
       expect(response).to be_a(Dnsimple::Response)
 
       result = response.data
       expect(result).to be_a(Dnsimple::Struct::Domain)
-      expect(result.id).to eq(1)
-      expect(result.account_id).to eq(1010)
-      expect(result.registrant_id).to eq(nil)
+      expect(result.id).to eq(181984)
+      expect(result.account_id).to eq(1385)
+      expect(result.registrant_id).to eq(2715)
       expect(result.name).to eq("example-alpha.com")
-      expect(result.state).to eq("hosted")
+      expect(result.state).to eq("registered")
       expect(result.auto_renew).to be(false)
       expect(result.private_whois).to be(false)
-      expect(result.expires_on).to eq(nil)
-      expect(result.created_at).to eq("2014-12-06T15:56:55Z")
-      expect(result.updated_at).to eq("2015-12-09T00:20:56Z")
+      expect(result.expires_at).to eq("2021-06-05T02:15:00Z")
+      expect(result.created_at).to eq("2020-06-04T19:15:14Z")
+      expect(result.updated_at).to eq("2020-06-04T19:15:21Z")
     end
 
     context "when the domain does not exist" do

--- a/spec/fixtures.http/createDomain/created.http
+++ b/spec/fixtures.http/createDomain/created.http
@@ -1,16 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Fri, 18 Dec 2015 16:38:07 GMT
+Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3986
-X-RateLimit-Reset: 1450456686
-ETag: W/"87e018b900e5f210c3236f63d3b2f4df"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2378
+X-RateLimit-Reset: 1591300248
+ETag: W/"399e70627412fa31dba332feca5e8ec1"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 0d6f1ea7-f702-4317-85f0-04874b69315d
-X-Runtime: 0.257489
+X-Request-Id: ee897eee-36cc-4b7f-be15-f4627f344bf9
+X-Runtime: 0.194561
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}}

--- a/spec/fixtures.http/getDomain/success.http
+++ b/spec/fixtures.http/getDomain/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 21:54:55 GMT
+Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1450302894
-ETag: W/"e7282090a87379d1fa3507ba6bfd1721"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2379
+X-RateLimit-Reset: 1591300247
+ETag: W/"ff4a8463ecca39d4869695d66de60043"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 3d8da18a-b8b2-4bfd-827c-860da837c80f
-X-Runtime: 0.020346
+X-Request-Id: 2e8259ab-c933-487e-8f85-d23f1cdf62fa
+X-Runtime: 0.019482
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"}}

--- a/spec/fixtures.http/listDomains/success.http
+++ b/spec/fixtures.http/listDomains/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 13:36:11 GMT
+Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3997
-X-RateLimit-Reset: 1450272970
-ETag: W/"2679531e6cce6cd326f255255d7a0005"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1591304056
+ETag: W/"732eac2d85c19810f4e84dbc0eaafb9d"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: a87f1b44-150a-4ed0-b7da-9301fa1465b0
-X-Runtime: 0.093714
+X-Request-Id: 458d7b96-bb1a-469a-817e-4fd65c0f1db3
+X-Runtime: 0.125593
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"},{"id":2,"account_id":1010,"registrant_id":21,"name":"example-beta.com","unicode_name":"example-beta.com","token":"domain-token","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2015-12-06","created_at":"2014-12-06T15:46:52Z","updated_at":"2015-12-09T00:20:53Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"},{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
We deprecated expires_on attribute in our documentation in favor of
expires_at. This commit introduces the new field and removes the old
one. It also updates to use the new fixtures.

This is a breaking change, so we can bump the major version.