### PR TITLE
Remove deprecated expires_on attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 - REMOVED: `domain.reset_domain_token` endpoint no longer exists and the client method is removed.
   (dnsimple/dnsimple-ruby#231)
+- REMOVED: The deprecated `Domain.expires_on` is removed. (dnsimple/dnsimple-ruby#232)
+- REMOVED: The deprecated `Certificate.expires_on` is removed. (dnsimple/dnsimple-ruby#232)
 
 ## 5.2.0
 

--- a/lib/dnsimple/struct/certificate.rb
+++ b/lib/dnsimple/struct/certificate.rb
@@ -4,13 +4,6 @@ module Dnsimple
   module Struct
 
     class Certificate < Base
-
-      def initialize(attributes = {})
-        attributes.delete("expires_on")
-        super
-        @expires_on = Date.parse(expires_at).to_s if expires_at
-      end
-
       # @return [Integer] The certificate ID in DNSimple.
       attr_accessor :id
 
@@ -49,18 +42,6 @@ module Dnsimple
 
       # @return [String] The timestamp when the certificate will expire.
       attr_accessor :expires_at
-
-      # @deprecated Please use #expires_at instead.
-      # @return [String] The date when the certificate will expire.
-      def expires_on
-        warn "[DEPRECATION] Certificate#expires_on is deprecated. Please use `expires_at` instead."
-        @expires_on
-      end
-
-      def expires_on=(expiration_date)
-        warn "[DEPRECATION] Certificate#expires_on= is deprecated. Please use `expires_at=` instead."
-        @expires_on = expiration_date
-      end
     end
 
   end

--- a/lib/dnsimple/struct/domain.rb
+++ b/lib/dnsimple/struct/domain.rb
@@ -4,13 +4,6 @@ module Dnsimple
   module Struct
 
     class Domain < Base
-
-      def initialize(attributes = {})
-        attributes.delete("expires_on")
-        super
-        @expires_on = Date.parse(expires_at).to_s if expires_at
-      end
-
       # @return [Integer] The domain ID in DNSimple.
       attr_accessor :id
 
@@ -43,19 +36,6 @@ module Dnsimple
 
       # @return [String] When the domain was last updated in DNSimple.
       attr_accessor :updated_at
-
-      # @deprecated Please use #expires_at instead.
-      # @return [String] The date the domain will expire.
-      def expires_on
-        warn "[DEPRECATION] Domain#expires_on is deprecated. Please use `expires_at` instead."
-        @expires_on
-      end
-
-      def expires_on=(expiration_date)
-        warn "[DEPRECATION] Domain#expires_on= is deprecated. Please use `expires_at=` instead."
-        @expires_on = expiration_date
-      end
-
     end
   end
 end

--- a/spec/dnsimple/client/certificates_spec.rb
+++ b/spec/dnsimple/client/certificates_spec.rb
@@ -120,7 +120,6 @@ describe Dnsimple::Client, ".certificates" do
       expect(result.auto_renew).to be(false)
       expect(result.created_at).to eq("2020-06-18T18:54:17Z")
       expect(result.updated_at).to eq("2020-06-18T19:10:14Z")
-      expect(result.expires_on).to eq("2020-09-16")
       expect(result.expires_at).to eq("2020-09-16T18:10:13Z")
     end
 

--- a/spec/dnsimple/client/domains_spec.rb
+++ b/spec/dnsimple/client/domains_spec.rb
@@ -153,7 +153,6 @@ describe Dnsimple::Client, ".domains" do
       expect(result.auto_renew).to be(false)
       expect(result.private_whois).to be(false)
       expect(result.expires_at).to eq("2021-06-05T02:15:00Z")
-      expect(result.expires_on).to eq("2021-06-05")
       expect(result.created_at).to eq("2020-06-04T19:15:14Z")
       expect(result.updated_at).to eq("2020-06-04T19:15:21Z")
     end


### PR DESCRIPTION
This commit drops the deprecated expires_on from Domain and Certificate.
This attribute was deprecated in favor of expires_at.

Since we will do a major release, it is a good time to remove these deprecated attributes.