### PR TITLE
Update Fixtures with the removal of Transfer-Encoding

### DIFF
--- a/spec/dnsimple/client/domains_email_forwards_spec.rb
+++ b/spec/dnsimple/client/domains_email_forwards_spec.rb
@@ -129,7 +129,7 @@ describe Dnsimple::Client, ".domains" do
   describe "#email_forward" do
     let(:account_id) { 1010 }
     let(:domain_id) { "example.com" }
-    let(:email_forward_id) { 17706 }
+    let(:email_forward_id) { 41872 }
 
     before do
       stub_request(:get, %r{/v2/#{account_id}/domains/#{domain_id}/email_forwards.+$})
@@ -149,12 +149,12 @@ describe Dnsimple::Client, ".domains" do
 
       result = response.data
       expect(result).to be_a(Dnsimple::Struct::EmailForward)
-      expect(result.id).to eq(17706)
-      expect(result.domain_id).to eq(228963)
-      expect(result.from).to eq("jim@a-domain.com")
-      expect(result.to).to eq("jim@another.com")
-      expect(result.created_at).to eq("2016-02-04T14:26:50Z")
-      expect(result.updated_at).to eq("2016-02-04T14:26:50Z")
+      expect(result.id).to eq(41872)
+      expect(result.domain_id).to eq(235146)
+      expect(result.from).to eq("example@dnsimple.xyz")
+      expect(result.to).to eq("example@example.com")
+      expect(result.created_at).to eq("2021-01-25T13:54:40Z")
+      expect(result.updated_at).to eq("2021-01-25T13:54:40Z")
     end
 
     context "when the email forward does not exist" do

--- a/spec/fixtures.http/accounts/success-account.http
+++ b/spec/fixtures.http/accounts/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/spec/fixtures.http/accounts/success-user.http
+++ b/spec/fixtures.http/accounts/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/spec/fixtures.http/addCollaborator/invite-success.http
+++ b/spec/fixtures.http/addCollaborator/invite-success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:51:12 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/addCollaborator/success.http
+++ b/spec/fixtures.http/addCollaborator/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:53:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/appliedServices/success.http
+++ b/spec/fixtures.http/appliedServices/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 15 Jun 2016 11:09:44 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/cancelDomainTransfer/success.http
+++ b/spec/fixtures.http/cancelDomainTransfer/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Fri, 05 Jun 2020 18:09:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/spec/fixtures.http/changeDomainDelegation/success.http
+++ b/spec/fixtures.http/changeDomainDelegation/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/changeDomainDelegationToVanity/success.http
+++ b/spec/fixtures.http/changeDomainDelegationToVanity/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 11 Jul 2016 09:40:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/checkDomain/success.http
+++ b/spec/fixtures.http/checkDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 26 Feb 2016 16:04:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
+++ b/spec/fixtures.http/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:43:02 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4786
+X-RateLimit-Reset: 1595859922
+Cache-Control: no-cache
+X-Request-Id: 382b409c-0f90-4758-af3b-0bccd31a9d0d
+X-Runtime: 1.346405
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"`cocotero.love` is not a premium domain for registration"}

--- a/spec/fixtures.http/checkDomainPremiumPrice/error_400_tld_not_supported.http
+++ b/spec/fixtures.http/checkDomainPremiumPrice/error_400_tld_not_supported.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:41:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1595860823
+Cache-Control: no-cache
+X-Request-Id: 6986cca3-4f57-4814-9e81-1c484d61c7ea
+X-Runtime: 0.007339
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"TLD .LOVE is not supported"}

--- a/spec/fixtures.http/checkDomainPremiumPrice/success.http
+++ b/spec/fixtures.http/checkDomainPremiumPrice/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Jul 2020 13:58:50 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4769
+X-RateLimit-Reset: 1595859923
+ETag: W/"54b4776b898065f2f551fc33465d0936"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 75c5090e-8000-4e95-a516-ffd09383f641
+X-Runtime: 2.380524
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"premium_price":"2640.00","action":"registration"}}

--- a/spec/fixtures.http/checkZoneDistribution/error.http
+++ b/spec/fixtures.http/checkZoneDistribution/error.http
@@ -2,7 +2,6 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/checkZoneDistribution/failure.http
+++ b/spec/fixtures.http/checkZoneDistribution/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/checkZoneDistribution/success.http
+++ b/spec/fixtures.http/checkZoneDistribution/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/checkZoneRecordDistribution/error.http
+++ b/spec/fixtures.http/checkZoneRecordDistribution/error.http
@@ -2,7 +2,6 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/checkZoneRecordDistribution/failure.http
+++ b/spec/fixtures.http/checkZoneRecordDistribution/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/checkZoneRecordDistribution/success.http
+++ b/spec/fixtures.http/checkZoneRecordDistribution/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:48:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/createContact/created.http
+++ b/spec/fixtures.http/createContact/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 19 Jan 2016 20:50:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/createDelegationSignerRecord/created.http
+++ b/spec/fixtures.http/createDelegationSignerRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 15:24:00 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/createDelegationSignerRecord/validation-error.http
+++ b/spec/fixtures.http/createDelegationSignerRecord/validation-error.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Fri, 03 Mar 2017 15:20:28 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/spec/fixtures.http/createDomain/created.http
+++ b/spec/fixtures.http/createDomain/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2378

--- a/spec/fixtures.http/createEmailForward/created.http
+++ b/spec/fixtures.http/createEmailForward/created.http
@@ -1,17 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Thu, 04 Feb 2016 14:26:51 GMT
+Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3991
-X-RateLimit-Reset: 1454596042
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4772
+X-RateLimit-Reset: 1611583415
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fca523a2-aad9-49e6-a828-a0e7711a8501
-X-Runtime: 1.711621
+X-Request-Id: 1086590f-0e65-4010-8636-031400a662bf
+X-Runtime: 0.880228
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}

--- a/spec/fixtures.http/createPrimaryServer/created.http
+++ b/spec/fixtures.http/createPrimaryServer/created.http
@@ -1,0 +1,21 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 17 Mar 2021 23:08:42 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2388
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 24ed1594-6701-475b-b66b-f85f9fe69736
+X-Runtime: 0.162800
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/spec/fixtures.http/createSecondaryZone/created.http
+++ b/spec/fixtures.http/createSecondaryZone/created.http
@@ -1,0 +1,21 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 17 Mar 2021 23:44:27 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1616028241
+ETag: W/"9726e9abb694bb7a61777076d14158fd"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 967ead79-85e7-4950-aa70-52da90f9abcc
+X-Runtime: 0.294142
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":734,"account_id":531,"name":"secondaryexample.com","reverse":false,"secondary":true,"last_transferred_at":null,"created_at":"2021-03-17T23:44:27Z","updated_at":"2021-03-17T23:44:27Z"}}

--- a/spec/fixtures.http/createTemplate/created.http
+++ b/spec/fixtures.http/createTemplate/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 24 Mar 2016 11:09:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/createTemplateRecord/created.http
+++ b/spec/fixtures.http/createTemplateRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 03 May 2016 07:51:33 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/createWebhook/created.http
+++ b/spec/fixtures.http/createWebhook/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 15 Feb 2016 17:04:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/createZoneRecord/created-apex.http
+++ b/spec/fixtures.http/createZoneRecord/created-apex.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/createZoneRecord/created.http
+++ b/spec/fixtures.http/createZoneRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/deleteContact/error-contact-in-use.http
+++ b/spec/fixtures.http/deleteContact/error-contact-in-use.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Wed, 11 Apr 2018 10:50:21 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1523447401
+Cache-Control: no-cache
+X-Request-Id: 8d9f3de7-6e42-4a16-82eb-e2434dd58008
+X-Runtime: 0.271090
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+{"message":"The contact cannot be deleted because it's currently in use"}

--- a/spec/fixtures.http/deleteEmailForward/success.http
+++ b/spec/fixtures.http/deleteEmailForward/success.http
@@ -1,13 +1,18 @@
 HTTP/1.1 204 No Content
 Server: nginx
-Date: Thu, 04 Feb 2016 17:14:52 GMT
+Date: Mon, 25 Jan 2021 13:56:43 GMT
 Connection: keep-alive
-Status: 204 No Content
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454609692
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4765
+X-RateLimit-Reset: 1611583416
 Cache-Control: no-cache
-X-Request-Id: 716d181c-495d-47ab-ab79-391a70e8abe1
-X-Runtime: 0.145208
+X-Request-Id: bfaceb73-4fd3-4490-8528-472ec1df3526
+X-Runtime: 0.506670
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 

--- a/spec/fixtures.http/disableDnssec/not-enabled.http
+++ b/spec/fixtures.http/disableDnssec/not-enabled.http
@@ -2,7 +2,6 @@ HTTP/1.1 428 Precondition Required
 Server: nginx
 Date: Fri, 03 Mar 2017 10:00:36 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/disableWhoisPrivacy/success.http
+++ b/spec/fixtures.http/disableWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/downloadCertificate/success.http
+++ b/spec/fixtures.http/downloadCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:53:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/enableDnssec/success.http
+++ b/spec/fixtures.http/enableDnssec/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 13:49:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/enableVanityNameServers/success.http
+++ b/spec/fixtures.http/enableVanityNameServers/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 14 Jul 2016 13:22:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/enableWhoisPrivacy/created.http
+++ b/spec/fixtures.http/enableWhoisPrivacy/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:52 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/enableWhoisPrivacy/success.http
+++ b/spec/fixtures.http/enableWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:49 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getCertificate/success.http
+++ b/spec/fixtures.http/getCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 18 Jun 2020 19:16:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4797

--- a/spec/fixtures.http/getCertificatePrivateKey/success.http
+++ b/spec/fixtures.http/getCertificatePrivateKey/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:50:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/getContact/success.http
+++ b/spec/fixtures.http/getContact/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 20:57:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getDelegationSignerRecord/success.http
+++ b/spec/fixtures.http/getDelegationSignerRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:53:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/getDnssec/success.http
+++ b/spec/fixtures.http/getDnssec/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 09:58:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/getDomain/success.http
+++ b/spec/fixtures.http/getDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2379

--- a/spec/fixtures.http/getDomainDelegation/success-empty.http
+++ b/spec/fixtures.http/getDomainDelegation/success-empty.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:13:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/getDomainDelegation/success.http
+++ b/spec/fixtures.http/getDomainDelegation/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/getDomainPremiumPrice/failure.http
+++ b/spec/fixtures.http/getDomainPremiumPrice/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Tue, 22 Nov 2016 10:48:27 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 1304138f-0fc7-4845-b9ed-e3803409cb5a

--- a/spec/fixtures.http/getDomainPremiumPrice/success.http
+++ b/spec/fixtures.http/getDomainPremiumPrice/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Nov 2016 10:46:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/getDomainPrices/failure.http
+++ b/spec/fixtures.http/getDomainPrices/failure.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:58 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1615217645
+Cache-Control: no-cache
+X-Request-Id: e414a674-63bb-4e54-b714-db5b516bb190
+X-Runtime: 0.009579
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+
+{"message":"TLD .PINEAPPLE is not supported"}

--- a/spec/fixtures.http/getDomainPrices/success.http
+++ b/spec/fixtures.http/getDomainPrices/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:26 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1615217645
+ETag: W/"2104f27f2877f429295359cfc409f9f7"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: b0d9e000-58a6-4254-af43-8735d26e12d9
+X-Runtime: 9.129301
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0}}

--- a/spec/fixtures.http/getDomainTransfer/success.http
+++ b/spec/fixtures.http/getDomainTransfer/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 05 Jun 2020 18:23:53 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2392

--- a/spec/fixtures.http/getEmailForward/success.http
+++ b/spec/fixtures.http/getEmailForward/success.http
@@ -1,17 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:42:46 GMT
+Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454600566
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4766
+X-RateLimit-Reset: 1611583416
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fde15363-9332-4b91-bd8f-00b144eb8081
-X-Runtime: 0.022117
+X-Request-Id: 8f3a9517-f623-4d14-be2b-3f332a4d7873
+X-Runtime: 0.010653
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}

--- a/spec/fixtures.http/getPrimaryServer/success.http
+++ b/spec/fixtures.http/getPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:18:40 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2386
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 259fc436-7146-4e6b-98fa-3c43f541482b
+X-Runtime: 0.033067
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/spec/fixtures.http/getService/success.http
+++ b/spec/fixtures.http/getService/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 15 Apr 2016 14:50:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/getTemplate/success.http
+++ b/spec/fixtures.http/getTemplate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:14:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/getTemplateRecord/success.http
+++ b/spec/fixtures.http/getTemplateRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:04:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/getTld/success.http
+++ b/spec/fixtures.http/getTld/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 09:06:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/getTldExtendedAttributes/success-attributes.http
+++ b/spec/fixtures.http/getTldExtendedAttributes/success-attributes.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getTldExtendedAttributes/success-noattributes.http
+++ b/spec/fixtures.http/getTldExtendedAttributes/success-noattributes.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getTldExtendedAttributes/success.http
+++ b/spec/fixtures.http/getTldExtendedAttributes/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getWebhook/success.http
+++ b/spec/fixtures.http/getWebhook/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:09 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getWhoisPrivacy/success.http
+++ b/spec/fixtures.http/getWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:35:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getZone/success.http
+++ b/spec/fixtures.http/getZone/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:14 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/getZoneFile/success.http
+++ b/spec/fixtures.http/getZoneFile/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 20 Jul 2016 09:04:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/getZoneRecord/success.http
+++ b/spec/fixtures.http/getZoneRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:53:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/spec/fixtures.http/initiatePush/success.http
+++ b/spec/fixtures.http/initiatePush/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 11 Aug 2016 10:16:03 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/spec/fixtures.http/issueLetsencryptCertificate/success.http
+++ b/spec/fixtures.http/issueLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Thu, 18 Jun 2020 18:56:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4798

--- a/spec/fixtures.http/issueRenewalLetsencryptCertificate/success.http
+++ b/spec/fixtures.http/issueRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Thu, 18 Jun 2020 20:05:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4798

--- a/spec/fixtures.http/linkPrimaryServer/success.http
+++ b/spec/fixtures.http/linkPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:29:51 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2384
+X-RateLimit-Reset: 1616024598
+ETag: W/"911f7a8bf729e066d3d0aedce7eaab4e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 104a8bbe-a4a7-41b1-9d51-499596f5b228
+X-Runtime: 0.249251
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":["secondaryzone.com"],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/spec/fixtures.http/listAccounts/success-account.http
+++ b/spec/fixtures.http/listAccounts/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/spec/fixtures.http/listAccounts/success-user.http
+++ b/spec/fixtures.http/listAccounts/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/spec/fixtures.http/listCertificates/success.http
+++ b/spec/fixtures.http/listCertificates/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 18 Jun 2020 20:35:23 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4797

--- a/spec/fixtures.http/listCollaborators/success.http
+++ b/spec/fixtures.http/listCollaborators/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 07 Oct 2016 08:58:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/listContacts/success.http
+++ b/spec/fixtures.http/listContacts/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 18:35:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/listDelegationSignerRecords/success.http
+++ b/spec/fixtures.http/listDelegationSignerRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:50:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/listDomains/success.http
+++ b/spec/fixtures.http/listDomains/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/listEmailForwards/success.http
+++ b/spec/fixtures.http/listEmailForwards/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Feb 2016 14:07:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/listPrimaryServers/success.http
+++ b/spec/fixtures.http/listPrimaryServers/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 22:45:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1616024598
+ETag: W/"1a8276fb3483d6954afe139480753c5b"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 411f7b7c-3ebb-4b6a-a986-5ffd8dcd4144
+X-Runtime: 0.159587
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":1,"account_id":531,"name":"Primary","ip":"1.1.1.1","port":4567,"linked_secondary_zones":[],"created_at":"2021-03-05T18:02:23Z","updated_at":"2021-03-05T18:02:23Z"},{"id":2,"account_id":531,"name":"Primary Production","ip":"1.1.1.1","port":4567,"linked_secondary_zones":["secondaryzone.com"],"created_at":"2021-03-16T20:33:34Z","updated_at":"2021-03-16T20:33:34Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/spec/fixtures.http/listPushes/success.http
+++ b/spec/fixtures.http/listPushes/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 11 Aug 2016 10:19:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/spec/fixtures.http/listServices/success.http
+++ b/spec/fixtures.http/listServices/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 10 Dec 2016 22:37:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/listTemplateRecords/success.http
+++ b/spec/fixtures.http/listTemplateRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:07:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/listTemplates/success.http
+++ b/spec/fixtures.http/listTemplates/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:11:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/listTlds/success.http
+++ b/spec/fixtures.http/listTlds/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 08:22:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/listWebhooks/success.http
+++ b/spec/fixtures.http/listWebhooks/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/listZoneRecords/success.http
+++ b/spec/fixtures.http/listZoneRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:27:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/listZones/success.http
+++ b/spec/fixtures.http/listZones/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/method-not-allowed.http
+++ b/spec/fixtures.http/method-not-allowed.http
@@ -1,7 +1,6 @@
 HTTP/1.1 405 Method Not Allowed
 Server: nginx
 Date: Fri, 15 Apr 2016 14:15:04 GMT
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 405 Method Not Allowed
 Allow: DELETE, GET, HEAD, PATCH, POST

--- a/spec/fixtures.http/notfound-certificate.http
+++ b/spec/fixtures.http/notfound-certificate.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jul 2016 08:56:34 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 9a51fa7e-cc9b-498b-bf8d-ee3b2819c0c6

--- a/spec/fixtures.http/notfound-collaborator.http
+++ b/spec/fixtures.http/notfound-collaborator.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Mon, 21 Nov 2016 09:32:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 3e76b10b-412c-42ef-87d1-f8ff327df997

--- a/spec/fixtures.http/notfound-contact.http
+++ b/spec/fixtures.http/notfound-contact.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jan 2016 21:04:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-delegationsignerrecord.http
+++ b/spec/fixtures.http/notfound-delegationsignerrecord.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-domain.http
+++ b/spec/fixtures.http/notfound-domain.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 16 Dec 2015 22:07:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Strict-Transport-Security: max-age=31536000
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-domainpush.http
+++ b/spec/fixtures.http/notfound-domainpush.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-emailforward.http
+++ b/spec/fixtures.http/notfound-emailforward.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-record.http
+++ b/spec/fixtures.http/notfound-record.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:07 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-template.http
+++ b/spec/fixtures.http/notfound-template.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 04 May 2016 09:35:45 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-webhook.http
+++ b/spec/fixtures.http/notfound-webhook.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 03 Mar 2016 11:55:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-whoisprivacy.http
+++ b/spec/fixtures.http/notfound-whoisprivacy.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:32 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/notfound-zone.http
+++ b/spec/fixtures.http/notfound-zone.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/spec/fixtures.http/oauthAccessToken/error-invalid-request.http
+++ b/spec/fixtures.http/oauthAccessToken/error-invalid-request.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 30
 X-RateLimit-Remaining: 29

--- a/spec/fixtures.http/oauthAccessToken/success.http
+++ b/spec/fixtures.http/oauthAccessToken/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 30

--- a/spec/fixtures.http/pages-1of3.http
+++ b/spec/fixtures.http/pages-1of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/spec/fixtures.http/pages-2of3.http
+++ b/spec/fixtures.http/pages-2of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/spec/fixtures.http/pages-3of3.http
+++ b/spec/fixtures.http/pages-3of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/spec/fixtures.http/purchaseLetsencryptCertificate/success.http
+++ b/spec/fixtures.http/purchaseLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 18 Jun 2020 18:54:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4799

--- a/spec/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
+++ b/spec/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 18 Jun 2020 19:56:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4799

--- a/spec/fixtures.http/registerDomain/success.http
+++ b/spec/fixtures.http/registerDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:35:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/renewDomain/error-tooearly.http
+++ b/spec/fixtures.http/renewDomain/error-tooearly.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 15 Feb 2016 15:06:35 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/renewDomain/success.http
+++ b/spec/fixtures.http/renewDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:46:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/spec/fixtures.http/renewWhoisPrivacy/success.http
+++ b/spec/fixtures.http/renewWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 10 Jan 2019 12:12:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/spec/fixtures.http/renewWhoisPrivacy/whois-privacy-duplicated-order.http
+++ b/spec/fixtures.http/renewWhoisPrivacy/whois-privacy-duplicated-order.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:13:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/spec/fixtures.http/renewWhoisPrivacy/whois-privacy-not-found.http
+++ b/spec/fixtures.http/renewWhoisPrivacy/whois-privacy-not-found.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:11:39 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/spec/fixtures.http/response.http
+++ b/spec/fixtures.http/response.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/spec/fixtures.http/transferDomain/error-indnsimple.http
+++ b/spec/fixtures.http/transferDomain/error-indnsimple.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/transferDomain/error-missing-authcode.http
+++ b/spec/fixtures.http/transferDomain/error-missing-authcode.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/transferDomain/success.http
+++ b/spec/fixtures.http/transferDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:43:43 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/spec/fixtures.http/unlinkPrimaryServer/success.http
+++ b/spec/fixtures.http/unlinkPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:36:43 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2383
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 789c6feb-63e1-40d6-b2b6-f569b23a507c
+X-Runtime: 0.270968
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/spec/fixtures.http/updateContact/success.http
+++ b/spec/fixtures.http/updateContact/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 21:28:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/spec/fixtures.http/updateTemplate/success.http
+++ b/spec/fixtures.http/updateTemplate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:04:55 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/spec/fixtures.http/updateZoneRecord/success.http
+++ b/spec/fixtures.http/updateZoneRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:59:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/spec/fixtures.http/validation-error.http
+++ b/spec/fixtures.http/validation-error.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Wed, 23 Nov 2016 08:12:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/spec/fixtures.http/whoami/success-account.http
+++ b/spec/fixtures.http/whoami/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/spec/fixtures.http/whoami/success-user.http
+++ b/spec/fixtures.http/whoami/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/spec/fixtures.http/whoami/success.http
+++ b/spec/fixtures.http/whoami/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991


### PR DESCRIPTION
After dnsimple/dnsimple-developer#337 we removed
the Transfer-Encoding from the fixtures.

This commit updates the project fixtures with the most recent ones.