### PR TITLE
Deprecates Registrar#domain_premium_price

### DIFF
--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -45,6 +45,7 @@ module Dnsimple
       #
       # @deprecated Use {#get_domain_prices} instead of this one as it will soon be removed from the API.
       def domain_premium_price(account_id, domain_name, options = {})
+        Dnsimple.deprecate("Use {#get_domain_prices} instead of this one as it will soon be removed from the API.")
         endpoint = Client.versioned("/%s/registrar/domains/%s/premium_price" % [account_id, domain_name])
         options[:query] = { action: options.delete(:action) } if options.key?(:action)
         response = client.get(endpoint, options)

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -42,6 +42,8 @@ module Dnsimple
       # @return [Struct::DomainPremiumPrice]
       #
       # @raise  [RequestError] When the request fails.
+      #
+      # @deprecated Use {#get_domain_prices} instead of this one as it will soon be removed from the API.
       def domain_premium_price(account_id, domain_name, options = {})
         endpoint = Client.versioned("/%s/registrar/domains/%s/premium_price" % [account_id, domain_name])
         options[:query] = { action: options.delete(:action) } if options.key?(:action)


### PR DESCRIPTION
Deprecates `domain_premium_price` in `Registrar` in favor of `get_domain_prices`