### PR TITLE
Adds the release GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+name: release
+
+on:
+  push:
+      tags:
+        - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      -name: Publish Package
+        run: gradle publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSH_TOKEN }}


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

 - [ ] add the `OSSH_USERNAME` to the secrets
 - [ ] add the `OSSH_TOKEN` to the secrets