### PR TITLE
Automating release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,17 @@ name: release
 
 on:
   push:
-      tags:
-        - v*.*.*
-
+    tags:
+      - v*.*.*
 jobs:
   publish:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-      -name: Publish Package
-        run: gradle publish
+
+      - name: Release Gem
+        uses: cadwallion/publish-rubygems-action@master
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSH_TOKEN }}
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RELEASE_COMMAND: rake build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
         uses: cadwallion/publish-rubygems-action@master
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-          RELEASE_COMMAND: rake build
+          RELEASE_COMMAND: rake release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Release Gem
-        uses: cadwallion/publish-rubygems-action@master
+        # v1.0.0
+        uses: cadwallion/publish-rubygems-action@9493635
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
           RELEASE_COMMAND: rake release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+name: release
+
+on:
+  push:
+      tags:
+        - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      -name: Publish Package
+        run: gradle publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSH_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,18 +53,6 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
     git push origin --tags
     ```
 
-1. Build the package.
-
-    ```shell
-    rake build
-    ```
-
-1. Release to RubyGems.
-
-    ```shell
-    gem push pkg/<filename>
-    ```
-
 ## Testing
 
 To run the test suite:


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

- [x] add the RUBYGEMS_API_KEY to the secrets