### PR TITLE
Use dependabot for handling GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,13 @@ updates:
     labels:
       - task
       - dependencies
-      - backlog-dependencies
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: '12:00'
+    open-pull-requests-limit: 10
+    labels:
+      - task
+      - dependencies


### PR DESCRIPTION
This PR configures dependabot to take care of the versions used in the GitHub actions

## :mag: QA

- N/A

## :shipit: Pre/Post tasks

- N/A


## :shipit: Verification

- [ ] Ensure we have PR's for GitHub actions