### PR TITLE
[Task] Deprecates Ruby v2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/dnsimple.gemspec
+++ b/dnsimple.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = 'The DNSimple API client for Ruby'
   s.description = 'The DNSimple API client for Ruby.'
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.require_paths    = ['lib']
   s.files            = `git ls-files`.split("\n")


### PR DESCRIPTION
Ruby v2.6 EOL happened on 31/Mar/2022