### PR TITLE
Removes deprecated method registrar#domain_premium_price

### DIFF
--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -24,35 +24,6 @@ module Dnsimple
         Dnsimple::Response.new(response, Struct::DomainCheck.new(response["data"]))
       end
 
-      # Checks the premium price for a domain
-      #
-      # @see https://developer.dnsimple.com/v2/registrar/#premium-price
-      #
-      # @example Check the ruby.codes premium price:
-      #   client.registrar.domain_premium_price(1010, "ruby.codes")
-      #
-      # @example Check the ruby.codes premium price for transfer:
-      #   client.registrar.domain_premium_price(1010, "ruby.codes", action: "transfer")
-      #
-      # @param  [Integer] account_id the account ID
-      # @param  [#to_s] domain_name the domain name to check
-      # @param  [Hash] options
-      # @option options [String] :action Optional action between "registration",
-      #   "renewal", and "transfer". If omitted, it defaults to "registration".
-      # @return [Struct::DomainPremiumPrice]
-      #
-      # @raise  [RequestError] When the request fails.
-      #
-      # @deprecated Use {#get_domain_prices} instead of this one as it will soon be removed from the API.
-      def domain_premium_price(account_id, domain_name, options = {})
-        Dnsimple.deprecate("Use {#get_domain_prices} instead of this one as it will soon be removed from the API.")
-        endpoint = Client.versioned("/%s/registrar/domains/%s/premium_price" % [account_id, domain_name])
-        options[:query] = { action: options.delete(:action) } if options.key?(:action)
-        response = client.get(endpoint, options)
-
-        Dnsimple::Response.new(response, Struct::DomainPremiumPrice.new(response["data"]))
-      end
-
       # Get prices for a domain.
       # @see https://developer.dnsimple.com/v2/registrar/#getDomainPrices
       #

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -34,54 +34,6 @@ describe Dnsimple::Client, ".registrar" do
     end
   end
 
-  describe "#domain_premium_price" do
-    let(:account_id) { 1010 }
-
-    context "when premium price" do
-      before do
-        stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/premium_price[?action]*})
-            .to_return(read_http_fixture("getDomainPremiumPrice/success.http"))
-      end
-
-      it "builds the correct request" do
-        subject.domain_premium_price(account_id, domain_name = "ruby.codes")
-
-        expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/premium_price")
-            .with(headers: { "Accept" => "application/json" })
-      end
-
-      it "returns the premium price" do
-        response = subject.domain_premium_price(account_id, "ruby.codes")
-        expect(response).to be_a(Dnsimple::Response)
-
-        result = response.data
-        expect(result).to be_a(Dnsimple::Struct::DomainPremiumPrice)
-        expect(result.premium_price).to eq("109.00")
-        expect(result.action).to        eq("registration")
-      end
-
-      it "builds the correct request when action is passed" do
-        subject.domain_premium_price(account_id, domain_name = "ruby.codes", action: "registration")
-
-        expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/premium_price?action=registration")
-            .with(headers: { "Accept" => "application/json" })
-      end
-    end
-
-    context "when not premium price" do
-      before do
-        stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/premium_price$})
-            .to_return(read_http_fixture("getDomainPremiumPrice/failure.http"))
-      end
-
-      it "raises error" do
-        expect {
-          subject.domain_premium_price(account_id, "example.com")
-        }.to raise_error(Dnsimple::RequestError, "`example.com` is not a premium domain for registration")
-      end
-    end
-  end
-
   describe "#get_domain_prices" do
     let(:account_id) { 1010 }
 


### PR DESCRIPTION
As we are moving forward with https://github.com/dnsimple/dnsimple-ruby/pull/288 pushing a new major version, we can also remove the deprecated method. 

`registrar.get_domain_prices` (https://github.com/dnsimple/dnsimple-ruby/pull/240)

