### PR TITLE
Expose all information available in error responses 

### DIFF
--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -7,14 +7,24 @@ module Dnsimple
 
   # RequestError is raised when an API request fails for an client, a server error or invalid request information.
   class RequestError < Error
-    attr_reader :http_response
+    attr_reader :http_response, :errors
 
     def initialize(http_response)
       @http_response = http_response
+      @errors = errors_from(http_response)
       super(message_from(http_response))
     end
 
     private
+
+    def errors_from(http_response)
+      content_type = http_response.headers["Content-Type"]
+      if content_type&.start_with?("application/json")
+        http_response.parsed_response["errors"]
+      else
+        {}
+      end
+    end
 
     def message_from(http_response)
       content_type = http_response.headers["Content-Type"]

--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -22,7 +22,7 @@ module Dnsimple
       if content_type&.start_with?("application/json")
         http_response.parsed_response["errors"]
       else
-        {}
+        nil
       end
     end
 

--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -7,17 +7,17 @@ module Dnsimple
 
   # RequestError is raised when an API request fails for an client, a server error or invalid request information.
   class RequestError < Error
-    attr_reader :http_response, :errors
+    attr_reader :http_response, :attribute_errors
 
     def initialize(http_response)
       @http_response = http_response
-      @errors = errors_from(http_response)
+      @attribute_errors = attribute_errors_from(http_response)
       super(message_from(http_response))
     end
 
     private
 
-    def errors_from(http_response)
+    def attribute_errors_from(http_response)
       return unless is_json_response?(http_response)
 
       http_response.parsed_response["errors"]

--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -18,22 +18,23 @@ module Dnsimple
     private
 
     def errors_from(http_response)
-      content_type = http_response.headers["Content-Type"]
-      if content_type&.start_with?("application/json")
-        http_response.parsed_response["errors"]
-      else
-        nil
-      end
+      return unless is_json_response?(http_response)
+
+      http_response.parsed_response["errors"]
     end
 
     def message_from(http_response)
-      content_type = http_response.headers["Content-Type"]
-      if content_type&.start_with?("application/json")
+      if is_json_response?(http_response)
         http_response.parsed_response["message"]
       else
         net_http_response = http_response.response
         "#{net_http_response.code} #{net_http_response.message}"
       end
+    end
+
+    def is_json_response?(http_response)
+      content_type = http_response.headers["Content-Type"]
+      content_type&.start_with?("application/json")
     end
 
   end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -90,7 +90,9 @@ describe Dnsimple::Client do
 
       expect {
         subject.execute(:post, "foo", {})
-      }.to raise_error(Dnsimple::RequestError, "The domain google.com is already in DNSimple and cannot be added")
+      }.to raise_error(Dnsimple::RequestError, "The domain google.com is already in DNSimple and cannot be added") do |exception|
+        expect(exception.errors).to be_nil
+      end
     end
 
     it "raises a Request error in case of an error with a JSON response with attribute errors" do
@@ -111,7 +113,9 @@ describe Dnsimple::Client do
 
       expect {
         subject.execute(:get, "foo", {})
-      }.to raise_error(Dnsimple::RequestError, "502 Bad Gateway")
+      }.to raise_error(Dnsimple::RequestError, "502 Bad Gateway") do |exception|
+        expect(exception.errors).to be_nil
+      end
     end
 
     it "raises RequestError in absence of content types" do
@@ -119,7 +123,9 @@ describe Dnsimple::Client do
 
       expect {
         subject.execute(:put, "foo", {})
-      }.to raise_error(Dnsimple::RequestError, "405 Method Not Allowed")
+      }.to raise_error(Dnsimple::RequestError, "405 Method Not Allowed") do |exception|
+        expect(exception.errors).to be_nil
+      end
     end
   end
 

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -100,7 +100,7 @@ describe Dnsimple::Client do
         subject.execute(:post, "foo", {})
       }.to raise_error(Dnsimple::RequestError, "Validation failed") do |exception|
         expect(exception).to respond_to(:errors)
-        expect(exception.errors).to be_kind_of(Hash)
+        expect(exception.errors).to be_a(Hash)
         expect(exception.errors["email"]).to eq(["can't be blank", "is an invalid email address"])
         expect(exception.errors["address1"]).to eq(["can't be blank"])
       end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -91,7 +91,7 @@ describe Dnsimple::Client do
       expect {
         subject.execute(:post, "foo", {})
       }.to raise_error(Dnsimple::RequestError, "The domain google.com is already in DNSimple and cannot be added") do |exception|
-        expect(exception.errors).to be_nil
+        expect(exception.attribute_errors).to be_nil
       end
     end
 
@@ -101,10 +101,10 @@ describe Dnsimple::Client do
       expect {
         subject.execute(:post, "foo", {})
       }.to raise_error(Dnsimple::RequestError, "Validation failed") do |exception|
-        expect(exception).to respond_to(:errors)
-        expect(exception.errors).to be_a(Hash)
-        expect(exception.errors["email"]).to eq(["can't be blank", "is an invalid email address"])
-        expect(exception.errors["address1"]).to eq(["can't be blank"])
+        expect(exception).to respond_to(:attribute_errors)
+        expect(exception.attribute_errors).to be_a(Hash)
+        expect(exception.attribute_errors["email"]).to eq(["can't be blank", "is an invalid email address"])
+        expect(exception.attribute_errors["address1"]).to eq(["can't be blank"])
       end
     end
 
@@ -114,7 +114,7 @@ describe Dnsimple::Client do
       expect {
         subject.execute(:get, "foo", {})
       }.to raise_error(Dnsimple::RequestError, "502 Bad Gateway") do |exception|
-        expect(exception.errors).to be_nil
+        expect(exception.attribute_errors).to be_nil
       end
     end
 
@@ -124,7 +124,7 @@ describe Dnsimple::Client do
       expect {
         subject.execute(:put, "foo", {})
       }.to raise_error(Dnsimple::RequestError, "405 Method Not Allowed") do |exception|
-        expect(exception.errors).to be_nil
+        expect(exception.attribute_errors).to be_nil
       end
     end
   end

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -93,6 +93,19 @@ describe Dnsimple::Client do
       }.to raise_error(Dnsimple::RequestError, "The domain google.com is already in DNSimple and cannot be added")
     end
 
+    it "raises a Request error in case of an error with a JSON response with attribute errors" do
+      stub_request(:post, %r{/foo}).to_return(read_http_fixture("validation-error.http"))
+
+      expect {
+        subject.execute(:post, "foo", {})
+      }.to raise_error(Dnsimple::RequestError, "Validation failed") do |exception|
+        expect(exception).to respond_to(:errors)
+        expect(exception.errors).to be_kind_of(Hash)
+        expect(exception.errors["email"]).to eq(["can't be blank", "is an invalid email address"])
+        expect(exception.errors["address1"]).to eq(["can't be blank"])
+      end
+    end
+
     it "raises RequestError in case of error with an HTML response" do
       stub_request(:get, %r{/foo}).to_return(read_http_fixture("badgateway.http"))
 


### PR DESCRIPTION
Our error responses sometimes include an `errors` entry with details about errors on the attributes of the specific resource. We handle those errors via `RequestError`, but we are only considering the message.

This PR:
- Introduces `ResponseError#errors` which exposes these errors in the Ruby client.