### PR TITLE
Pin down rubocop gems' version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 
 gem 'coveralls', require: false
 gem 'rubocop', '1.36.0', require: false
-gem 'rubocop-performance', require: false
-gem 'rubocop-rake', require: false
-gem 'rubocop-rspec', require: false
+gem 'rubocop-performance', '1.15.0', require: false
+gem 'rubocop-rake', '0.6.0', require: false
+gem 'rubocop-rspec', '2.13.1', require: false

--- a/spec/dnsimple/client/registrar_whois_privacy_spec.rb
+++ b/spec/dnsimple/client/registrar_whois_privacy_spec.rb
@@ -28,9 +28,9 @@ describe Dnsimple::Client, ".registrar" do
 
       result = response.data
       expect(result).to be_a(Dnsimple::Struct::WhoisPrivacy)
-      expect(result.domain_id).to be_kind_of(Integer)
+      expect(result.domain_id).to be_a(Integer)
       expect(result.enabled).to be(true)
-      expect(result.expires_on).to be_kind_of(String)
+      expect(result.expires_on).to be_a(String)
     end
   end
 
@@ -57,9 +57,9 @@ describe Dnsimple::Client, ".registrar" do
 
         result = response.data
         expect(result).to be_a(Dnsimple::Struct::WhoisPrivacy)
-        expect(result.domain_id).to be_kind_of(Integer)
+        expect(result.domain_id).to be_a(Integer)
         expect(result.enabled).to be(true)
-        expect(result.expires_on).to be_kind_of(String)
+        expect(result.expires_on).to be_a(String)
       end
     end
 
@@ -83,7 +83,7 @@ describe Dnsimple::Client, ".registrar" do
 
         result = response.data
         expect(result).to be_a(Dnsimple::Struct::WhoisPrivacy)
-        expect(result.domain_id).to be_kind_of(Integer)
+        expect(result.domain_id).to be_a(Integer)
         expect(result.enabled).to be_nil
         expect(result.expires_on).to be_nil
       end
@@ -112,9 +112,9 @@ describe Dnsimple::Client, ".registrar" do
 
       result = response.data
       expect(result).to be_a(Dnsimple::Struct::WhoisPrivacy)
-      expect(result.domain_id).to be_kind_of(Integer)
+      expect(result.domain_id).to be_a(Integer)
       expect(result.enabled).to be(false)
-      expect(result.expires_on).to be_kind_of(String)
+      expect(result.expires_on).to be_a(String)
     end
   end
 
@@ -140,10 +140,10 @@ describe Dnsimple::Client, ".registrar" do
 
       result = response.data
       expect(result).to be_a(Dnsimple::Struct::WhoisPrivacyRenewal)
-      expect(result.domain_id).to be_kind_of(Integer)
-      expect(result.whois_privacy_id).to be_kind_of(Integer)
+      expect(result.domain_id).to be_a(Integer)
+      expect(result.whois_privacy_id).to be_a(Integer)
       expect(result.enabled).to be(true)
-      expect(result.expires_on).to be_kind_of(String)
+      expect(result.expires_on).to be_a(String)
     end
 
     context "when whois privacy was't previously purchased" do

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -126,7 +126,7 @@ describe Dnsimple::Client do
     it "delegates to HTTParty" do
       stub_request(:get, %r{/foo})
 
-      allow(HTTParty).to receive(:get)
+      expect(HTTParty).to receive(:get)
           .with(
               "#{subject.base_url}foo", {
                 format: :json,
@@ -150,7 +150,9 @@ describe Dnsimple::Client do
               }
             )
 
-      subject.request(:put, 'foo', { something: "else" }, { query: { foo: "bar" }, headers: { "Custom" => "Header" } })
+      expect {
+        subject.request(:put, 'foo', { something: "else" }, { query: { foo: "bar" }, headers: { "Custom" => "Header" } })
+      }.not_to raise_error
     end
 
     it "handles non application/json content types" do
@@ -164,7 +166,9 @@ describe Dnsimple::Client do
               }
             )
 
-      subject.request(:post, 'foo', { something: "else" }, { headers: { "Content-Type" => "application/x-www-form-urlencoded" } })
+      expect {
+        subject.request(:post, 'foo', { something: "else" }, { headers: { "Content-Type" => "application/x-www-form-urlencoded" } })
+      }.not_to raise_error
     end
 
     it "includes options for proxy support" do
@@ -178,8 +182,10 @@ describe Dnsimple::Client do
               }
             )
 
-      subject = described_class.new(proxy: "example-proxy.com:4321")
-      subject.request(:get, "test", nil, {})
+      expect {
+        subject = described_class.new(proxy: "example-proxy.com:4321")
+        subject.request(:get, "test", nil, {})
+      }.not_to raise_error
     end
 
     it "supports custom user agent" do
@@ -190,8 +196,10 @@ describe Dnsimple::Client do
                 headers: hash_including("User-Agent" => "customAgent #{Dnsimple::Default::USER_AGENT}"), }
             )
 
-      subject = described_class.new(user_agent: "customAgent")
-      subject.request(:get, "test", nil)
+      expect {
+        subject = described_class.new(user_agent: "customAgent")
+        subject.request(:get, "test", nil)
+      }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Since we don't have this, unexpected build failures happen on new PRs, when the newer version of one of these gems is used in CI. You can currently see this with #298, where CI is failing with but is green for `main`.

This PR:
- Pins-down the version of the 3 rubocop sub-gems we are using (rubocop itself was already pinned-down).
- Fixes the recent warnings coming from the latest version of `rubocop-rspec`.