### PR TITLE
Implement getDomainRenewal and getDomainRegistration endpoints

### DIFF
--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -67,6 +67,28 @@ module Dnsimple
         Dnsimple::Response.new(response, Struct::DomainRegistration.new(response["data"]))
       end
 
+      # Retrieves the details of an existing domain registration.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/#getDomainRegistration
+      #
+      # @example Retrieve the registration 42 for example.com:
+      #   client.registrar.get_domain_registration(1010, "example.com", 42)
+      #
+      # @param  [Integer] account_id the account ID
+      # @param  [#to_s] domain_name the domain name
+      # @param  [Integer] domain_registration_id the domain registration ID
+      # @param  [Hash] options
+      # @return [Struct::DomainRegistration]
+      #
+      # @raise  [NotFoundError] When record is not found.
+      # @raise  [RequestError]  When the request fails.
+      def get_domain_registration(account_id, domain_name, domain_registration_id, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/registrations/%s" % [account_id, domain_name, domain_registration_id])
+        response = client.get(endpoint, options)
+
+        Dnsimple::Response.new(response, Struct::DomainRegistration.new(response["data"]))
+      end
+
       # Renews a domain.
       #
       # @see https://developer.dnsimple.com/v2/registrar/#renew

--- a/lib/dnsimple/client/registrar.rb
+++ b/lib/dnsimple/client/registrar.rb
@@ -110,6 +110,28 @@ module Dnsimple
         Dnsimple::Response.new(response, Struct::DomainRenewal.new(response["data"]))
       end
 
+      # Retrieve the details of an existing domain renewal.
+      #
+      # @see https://developer.dnsimple.com/v2/registrar/#getDomainRenewal
+      #
+      # @example Retrieve the renewal 42 for example.com:
+      #   client.registrar.get_domain_renewal(1010, "example.com", 42)
+      #
+      # @param  [Integer] account_id the account ID
+      # @param  [#to_s] domain_name the domain name
+      # @param  [Integer] domain_renewal_id the domain renewal ID
+      # @param  [Hash] options
+      # @return [Struct::DomainRenewal]
+      #
+      # @raise  [NotFoundError] When record is not found.
+      # @raise  [RequestError]  When the request fails.
+      def get_domain_renewal(account_id, domain_name, domain_renewal_id, options = {})
+        endpoint = Client.versioned("/%s/registrar/domains/%s/renewals/%s" % [account_id, domain_name, domain_renewal_id])
+        response = client.get(endpoint, options)
+
+        Dnsimple::Response.new(response, Struct::DomainRenewal.new(response["data"]))
+      end
+
       # Starts the transfer of a domain to DNSimple.
       #
       # @see https://developer.dnsimple.com/v2/registrar/#transfer

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -178,6 +178,32 @@ describe Dnsimple::Client, ".registrar" do
     end
   end
 
+  describe "#get_domain_renewal" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/renewals/.+$})
+          .to_return(read_http_fixture("getDomainRenewal/success.http"))
+    end
+
+    it "builds the correct request" do
+      subject.get_domain_renewal(account_id, domain_name = "example.com", renewal_id = 361)
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/renewals/#{renewal_id}")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the domain renewal" do
+      response = subject.get_domain_renewal(account_id, "example.com", 361)
+      expect(response).to be_a(Dnsimple::Response)
+
+      result = response.data
+      expect(result).to be_a(Dnsimple::Struct::DomainRenewal)
+      expect(result.id).to be_a(Integer)
+      expect(result.domain_id).to be_a(Integer)
+    end
+  end
+
   describe "#transfer_domain" do
     let(:account_id) { 1010 }
     let(:attributes) { { registrant_id: "10", auth_code: "x1y2z3" } }

--- a/spec/dnsimple/client/registrar_spec.rb
+++ b/spec/dnsimple/client/registrar_spec.rb
@@ -112,6 +112,32 @@ describe Dnsimple::Client, ".registrar" do
     end
   end
 
+  describe "#get_domain_registration" do
+    let(:account_id) { 1010 }
+
+    before do
+      stub_request(:get, %r{/v2/#{account_id}/registrar/domains/.+/registrations/.+$})
+          .to_return(read_http_fixture("getDomainRegistration/success.http"))
+    end
+
+    it "builds the correct request" do
+      subject.get_domain_registration(account_id, domain_name = "example.com", registration_id = 361)
+
+      expect(WebMock).to have_requested(:get, "https://api.dnsimple.test/v2/#{account_id}/registrar/domains/#{domain_name}/registrations/#{registration_id}")
+          .with(headers: { "Accept" => "application/json" })
+    end
+
+    it "returns the domain transfer" do
+      response = subject.get_domain_registration(account_id, "example.com", 361)
+      expect(response).to be_a(Dnsimple::Response)
+
+      result = response.data
+      expect(result).to be_a(Dnsimple::Struct::DomainRegistration)
+      expect(result.id).to be_a(Integer)
+      expect(result.domain_id).to be_a(Integer)
+    end
+  end
+
   describe "#renew_domain" do
     let(:account_id) { 1010 }
     let(:attributes) { { period: "3" } }

--- a/spec/fixtures.http/getDomainRegistration/success.http
+++ b/spec/fixtures.http/getDomainRegistration/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 05 Jun 2020 18:23:53 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":361,"domain_id":104040,"registrant_id":2715,"period":1,"state":"registering","auto_renew":false,"whois_privacy":false,"created_at":"2023-01-27T17:44:32Z","updated_at":"2023-01-27T17:44:40Z"}}

--- a/spec/fixtures.http/getDomainRenewal/success.http
+++ b/spec/fixtures.http/getDomainRenewal/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"period":1,"state":"renewed","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}


### PR DESCRIPTION
Recently we introduced two new endpoints (https://github.com/dnsimple/dnsimple-developer/pull/457) in our API for users to retrieve their domain registration and renewal service objects.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1674