### PR TITLE
Wrap OAuth 400 errors in Dnsimple::OAuthInvalidRequestError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- CHANGED: Wrap 400 errors on the OAuth endpoint in `Dnsimple::OAuthInvalidRequestError` (dnsimple/dnsimple-ruby#336)
+
 ## 8.2.0
 
 - NEW: Added getDomainRenewal and getDomainRegistration endpoints (dnsimple/dnsimple-ruby#332)

--- a/lib/dnsimple/client/oauth.rb
+++ b/lib/dnsimple/client/oauth.rb
@@ -19,6 +19,11 @@ module Dnsimple
         attributes[:redirect_uri] = options.delete(:redirect_uri) if options.key?(:redirect_uri)
         response = client.post(Client.versioned("/oauth/access_token"), attributes, options)
         Struct::OauthToken.new(response)
+
+      rescue Dnsimple::RequestError => exception
+        raise exception unless exception.http_response.code == 400
+
+        raise Dnsimple::OAuthInvalidRequestError, exception.http_response
       end
 
       # Gets the URL to authorize an user for an application via the OAuth2 flow.

--- a/lib/dnsimple/error.rb
+++ b/lib/dnsimple/error.rb
@@ -48,4 +48,21 @@ module Dnsimple
   class AuthenticationFailed < AuthenticationError
   end
 
+  class OAuthInvalidRequestError < Error
+    attr_reader :http_response, :error, :error_description
+
+    def initialize(http_response)
+      @http_response = http_response
+      @error = http_response.parsed_response["error"]
+      @error_description = http_response.parsed_response["error_description"]
+      super(message)
+    end
+
+    private
+
+    def message
+      "#{error}: #{error_description}"
+    end
+  end
+
 end

--- a/spec/dnsimple/client/oauth_spec.rb
+++ b/spec/dnsimple/client/oauth_spec.rb
@@ -46,6 +46,25 @@ describe Dnsimple::Client, ".oauth" do
             .with(headers: { 'Accept' => 'application/json' })
       end
     end
+
+    context "when the request fails with 400" do
+      before do
+        stub_request(:post, %r{/v2/oauth/access_token$})
+            .to_return(read_http_fixture("oauthAccessToken/error-invalid-request.http"))
+      end
+
+      it "raises OAuthInvalidRequestError" do
+        expect {
+          subject.exchange_authorization_for_token(code, client_id, client_secret, state: state)
+        }.to raise_error(Dnsimple::OAuthInvalidRequestError) do |e|
+          error = "invalid_request"
+          error_description = "Invalid \"state\": value doesn't match the \"state\" in the authorization request"
+          expect(e.error).to eq(error)
+          expect(e.error_description).to eq(error_description)
+          expect(e.to_s).to eq("#{error}: #{error_description}")
+        end
+      end
+    end
   end
 
   describe "#authorize_url" do


### PR DESCRIPTION
Our standard request error class `Dnsimple::RequestError` does not support parsing OAuth request errors as their payload schema follows [RFC 6749](https://tools.ietf.org/html/rfc6749#section-4.1.2.1).

This PR detects 400 exceptions in the OAuth endpoint and re-packages the exception as `Dnsimple::OAuthInvalidRequestError` which correctly parses the error and exposes `#error` and `#error_description` methods to read the exception.

Fixes #103 