### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 8.4.0 (Unreleased)
+
+FEATURES:
+
+- Added `Dnsimple::Client::Zones` `#activate_dns` and `#deactivate_dns` methods to activate and deactivate DNS services for a zone. (dnsimple/dnsimple-ruby#354)
+
 ## 8.3.1
 
 - FIXED: Our release process had failed to push correctly `8.2.0` and `8.3.0` to RubyGems resulting in empty gem releases. This releases fixes the issue and contains the same changes of `8.2.0` and `8.3.0`.

--- a/lib/dnsimple/client/zones.rb
+++ b/lib/dnsimple/client/zones.rb
@@ -95,6 +95,40 @@ module Dnsimple
         Dnsimple::Response.new(response, Struct::ZoneFile.new(response["data"]))
       end
 
+      # Activate DNS resolution for the zone in the account.
+      #
+      # @see https://developer.dnsimple.com/v2/zones/#activateZoneService
+      #
+      # @param  [#to_s] account_id the account ID
+      # @param  [#to_s] zone_id the zone name
+      # @param  [Hash] options
+      # @return [Dnsimple::Response<Dnsimple::Struct::Zone>]
+      #
+      # @raise  [Dnsimple::NotFoundError]
+      # @raise  [Dnsimple::RequestError]
+      def activate_dns(account_id, zone_id, options = {})
+        response = client.put(Client.versioned("/%s/zones/%s/activation" % [account_id, zone_id]), options)
+
+        Dnsimple::Response.new(response, Struct::Zone.new(response["data"]))
+      end
+
+      # Deactivate DNS resolution for the zone in the account.
+      #
+      # @see https://developer.dnsimple.com/v2/zones/#deactivateZoneService
+      #
+      # @param  [#to_s] account_id the account ID
+      # @param  [#to_s] zone_id the zone name
+      # @param  [Hash] options
+      # @return [Dnsimple::Response<Dnsimple::Struct::Zone>]
+      #
+      # @raise  [Dnsimple::NotFoundError]
+      # @raise  [Dnsimple::RequestError]
+      def deactivate_dns(account_id, zone_id, options = {})
+        response = client.delete(Client.versioned("/%s/zones/%s/activation" % [account_id, zone_id]), options)
+
+        Dnsimple::Response.new(response, Struct::Zone.new(response["data"]))
+      end
+
     end
   end
 end

--- a/spec/fixtures.http/activateZoneService/success.http
+++ b/spec/fixtures.http/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2022-09-28T04:45:24Z","updated_at":"2023-07-06T11:19:48Z"}}

--- a/spec/fixtures.http/deactivateZoneService/success.http
+++ b/spec/fixtures.http/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2022-09-28T04:45:24Z","updated_at":"2023-08-08T04:19:52Z"}}


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2