### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `#secondary`, `#last_transferred_at`, `#active` to `Dnsimple::Struct::Zone` (dnsimple/dnsimple-ruby)
+
 ## 8.7.0
 
 FEATURES:

--- a/lib/dnsimple/struct/zone.rb
+++ b/lib/dnsimple/struct/zone.rb
@@ -16,6 +16,15 @@ module Dnsimple
       # @return [Boolean] True if the zone is a reverse zone.
       attr_accessor :reverse
 
+      # @return [Boolean] True if the zone is a secondary zone.
+      attr_accessor :secondary
+
+      # @return [String] When the zone was last transferred from another provider.
+      attr_accessor :last_transferred_at
+
+      # @return [Boolean] True if DNS services are active for the zone. False when DNS services are disabled and DNS records will not be resolved
+      attr_accessor :active
+
       # @return [String] When the zone was created in DNSimple.
       attr_accessor :created_at
 

--- a/spec/dnsimple/client/zones_spec.rb
+++ b/spec/dnsimple/client/zones_spec.rb
@@ -120,6 +120,9 @@ describe Dnsimple::Client, ".zones" do
       expect(result.account_id).to eq(1010)
       expect(result.name).to eq("example-alpha.com")
       expect(result.reverse).to be(false)
+      expect(result.secondary).to be(false)
+      expect(result.last_transferred_at).to be_nil
+      expect(result.active).to be(true)
       expect(result.created_at).to eq("2015-04-23T07:40:03Z")
       expect(result.updated_at).to eq("2015-04-23T07:40:03Z")
     end
@@ -197,6 +200,7 @@ describe Dnsimple::Client, ".zones" do
       expect(result.account_id).to eq(1010)
       expect(result.name).to eq("example.com")
       expect(result.reverse).to be(false)
+      expect(result.active).to be(true)
       expect(result.created_at).to eq("2022-09-28T04:45:24Z")
       expect(result.updated_at).to eq("2023-07-06T11:19:48Z")
     end
@@ -238,6 +242,7 @@ describe Dnsimple::Client, ".zones" do
       expect(result.account_id).to eq(1010)
       expect(result.name).to eq("example.com")
       expect(result.reverse).to be(false)
+      expect(result.active).to be(false)
       expect(result.created_at).to eq("2022-09-28T04:45:24Z")
       expect(result.updated_at).to eq("2023-08-08T04:19:52Z")
     end

--- a/spec/fixtures.http/getZone/success.http
+++ b/spec/fixtures.http/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/spec/fixtures.http/listZones/success.http
+++ b/spec/fixtures.http/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `#secondary`, `#last_transferred_at`, `#active` to `Dnsimple::Struct::Zone`

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17