### PR TITLE
This PR fixes a bug where providing `base_url: "api.dnsimple.com"` results in broken requests

### DIFF
--- a/lib/dnsimple/client.rb
+++ b/lib/dnsimple/client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'httparty'
+require 'uri'
+require 'uri/https'
 require 'dnsimple/extra'
 require 'dnsimple/struct'
 require 'dnsimple/response'
@@ -68,6 +70,10 @@ module Dnsimple
 
 
     def initialize(options = {})
+      options = options.clone.tap do |options|
+        options[:base_url] = normalized_base_url_option(options[:base_url])
+      end
+
       defaults = Dnsimple::Default.options
 
       Dnsimple::Default.keys.each do |key| # rubocop:disable Style/HashEachMethods
@@ -201,6 +207,16 @@ module Dnsimple
 
 
     private
+
+    def normalized_base_url_option(base_url)
+      if base_url.nil? || base_url == ""
+        nil
+      elsif URI.parse(base_url).scheme.nil?
+        URI::HTTPS.build(host: base_url).to_s
+      else
+        base_url
+      end
+    end
 
     def request_options(custom_options = {})
       base_options.tap do |options|

--- a/spec/dnsimple/client_spec.rb
+++ b/spec/dnsimple/client_spec.rb
@@ -20,9 +20,24 @@ describe Dnsimple::Client do
       expect(subject.base_url).to eq("https://api.example.com/missing/slash/")
     end
 
-    it "defaults :base_url to production API" do
+    it "defaults :base_url to production API when option omitted" do
       subject = described_class.new
       expect(subject.base_url).to eq("https://api.dnsimple.com/")
+    end
+
+    it "defaults :base_url to production API on nil" do
+      subject = described_class.new(base_url: nil)
+      expect(subject.base_url).to eq("https://api.dnsimple.com/")
+    end
+
+    it "defaults :base_url to production API on empty string" do
+      subject = described_class.new(base_url: "")
+      expect(subject.base_url).to eq("https://api.dnsimple.com/")
+    end
+
+    it "normalizes :base_url to use https when scheme missing" do
+      subject = described_class.new(base_url: 'api.example.com')
+      expect(subject.base_url).to eq("https://api.example.com/")
     end
   end
 


### PR DESCRIPTION
A user provided `base_url` is never normalized and results in downstream errors. This PR addresses the issue.

Both
- `Client.new base_url: nil`
- `Client.new base_url: "https://api.dnsimple.com"`

Result in
- `client.base_url # => "https://api.dnsimple.com"`

However, passing
- `Client.new base_url: "api.dnsimple.com"`, or
- `Client.new base_url: ""`

Are not normalized and do not error until requests are made. The errors are fairly opaque in nature. Because of the use of HTTParty, and its use of net/http, passing `"api.dnsimple.com"` to the constructor results in the error:
```
Failed to open TCP connection to :80 (Connection refused - connect(2) for nil port 80) (Errno::ECONNREFUSED)
```

It looks like the `api.dnsimple.com` is interpreted as a `path` component, and assumes http and port 80.

To ensure `https` as the default scheme, this PR adds nominal normalization for the `base_url` when passed as an option. It also coerces "" to nil, to results in the fallback/default base_url. This doesn't change the normalization for base_url on the client. It only adds it to the `options[:base_url]` which is passed _to_ the client.

---
Full logs of this error are below:
```
reproduction demo-user-$ cat Gemfile
gem "dnsimple", path: '../dnsimple-ruby'
reproduction demo-user-$ bundle exec irb
irb(main):001> require 'dnsimple'
=> true
irb(main):002> client = Dnsimple::Client.new base_url: 'api.dnsimple.com'
=> 
#<Dnsimple::Client:0x00007f4159b101b0
...
irb(main):003> client.identity.whoami
/home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `initialize': Failed to open TCP connection to :80 (Connection refused - connect(2) for nil port 80) (Errno::ECONNREFUSED)
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `open'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `block in connect'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/timeout.rb:186:in `block in timeout'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/timeout.rb:193:in `timeout'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1601:in `connect'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1580:in `do_start'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1569:in `start'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:2297:in `request'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty/request.rb:156:in `perform'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:611:in `perform_request'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:521:in `get'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:644:in `get'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:199:in `request'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:164:in `execute'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:110:in `get'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client/identity.rb:15:in `whoami'
        ... 20 levels...
/home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `initialize': Connection refused - connect(2) for nil port 80 (Errno::ECONNREFUSED)
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `open'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1603:in `block in connect'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/timeout.rb:186:in `block in timeout'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/timeout.rb:193:in `timeout'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1601:in `connect'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1580:in `do_start'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:1569:in `start'
        from /home/demo-user/.rubies/ruby-3.3.0/lib/ruby/3.3.0/net/http.rb:2297:in `request'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty/request.rb:156:in `perform'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:611:in `perform_request'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:521:in `get'
        from /home/demo-user/.gem/ruby/3.3.0/gems/httparty-0.22.0/lib/httparty.rb:644:in `get'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:199:in `request'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:164:in `execute'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client.rb:110:in `get'
        from /home/demo-user/projects/dnsimple-ruby/lib/dnsimple/client/identity.rb:15:in `whoami'
        ... 20 levels...

```