### PR TITLE
Add `active` attribute in `EmailForward` struct

### DIFF
--- a/lib/dnsimple/struct/email_forward.rb
+++ b/lib/dnsimple/struct/email_forward.rb
@@ -24,6 +24,9 @@ module Dnsimple
       # @return [String] The email recipient the messages are delivered to.
       attr_accessor :destination_email
 
+      # @return [Boolean] True if the email forward is active, false otherwise.
+      attr_accessor :active
+
       # @return [String] When the email forward was created in DNSimple.
       attr_accessor :created_at
 

--- a/lib/dnsimple/struct/email_forward.rb
+++ b/lib/dnsimple/struct/email_forward.rb
@@ -23,11 +23,11 @@ module Dnsimple
 
       # @return [String] The email recipient the messages are delivered to.
       attr_accessor :destination_email
-      # @return [String] Then the email forward was last updated in DNSimple.
 
       # @return [String] When the email forward was created in DNSimple.
       attr_accessor :created_at
 
+      # @return [String] When the email forward was last updated in DNSimple.
       attr_accessor :updated_at
 
     end

--- a/spec/dnsimple/client/domains_email_forwards_spec.rb
+++ b/spec/dnsimple/client/domains_email_forwards_spec.rb
@@ -46,12 +46,18 @@ describe Dnsimple::Client, ".domains" do
 
       expect(response).to be_a(Dnsimple::PaginatedResponse)
       expect(response.data).to be_a(Array)
-      expect(response.data.size).to eq(1)
+      expect(response.data.size).to eq(2)
 
-      response.data.each do |result|
-        expect(result).to be_a(Dnsimple::Struct::EmailForward)
-        expect(result.id).to be_a(Integer)
-      end
+      expect(response.data[0].id).to eq(24809)
+      expect(response.data[0].domain_id).to eq(235146)
+      expect(response.data[0].alias_email).to eq("foo@a-domain.com")
+      expect(response.data[0].destination_email).to eq("jane.smith@example.com")
+      expect(response.data[0].active).to be(true)
+      expect(response.data[1].id).to eq(24810)
+      expect(response.data[1].domain_id).to eq(235146)
+      expect(response.data[1].alias_email).to eq("bar@a-domain.com")
+      expect(response.data[1].destination_email).to eq("john.doe@example.com")
+      expect(response.data[1].active).to be(false)
     end
 
     it "exposes the pagination information" do

--- a/spec/fixtures.http/listEmailForwards/success.http
+++ b/spec/fixtures.http/listEmailForwards/success.http
@@ -13,4 +13,4 @@ X-Request-Id: e42df983-a8a5-4123-8c74-fb89ab934aba
 X-Runtime: 0.025456
 Strict-Transport-Security: max-age=63072000
 
-{"data":[{"id":24809,"domain_id":235146,"alias_email":".*@a-domain.com","destination_email":"jane.smith@example.com","created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":".*@a-domain.com","to":"jane.smith@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24809,"domain_id":235146,"alias_email":"foo@a-domain.com","destination_email":"jane.smith@example.com","active":true,"created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":"foo@a-domain.com","to":"jane.smith@example.com"},{"id":24810,"domain_id":235146,"alias_email":"bar@a-domain.com","destination_email":"john.doe@example.com","active":false,"created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":"bar@a-domain.com","to":"john.doe@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}


### PR DESCRIPTION
Fixes https://github.com/dnsimple/dnsimple-ruby/issues/399

This PR adds the new `active` attribute in the `EmailForward` struct to expose its value from DNSimple API's responses.