### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 - NEW: Added `alias_email` and `destination_email` to `EmailForward`
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
+- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 
 ## 9.0.0
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2022 DNSimple Corporation
+Copyright (c) 2010-2024 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ puts response.data
 
 ## License
 
-Copyright (c) 2010-2023 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2010-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/lib/dnsimple/client/domains_collaborators.rb
+++ b/lib/dnsimple/client/domains_collaborators.rb
@@ -20,9 +20,12 @@ module Dnsimple
       # @option options [Integer] :page current page (pagination)
       # @option options [Integer] :per_page number of entries to return (pagination)
       # @return [Dnsimple::PaginatedResponse<Dnsimple::Struct::Collaborator>]
+      # @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
       #
       # @raise  [Dnsimple::RequestError]
       def collaborators(account_id, domain_id, options = {})
+        Dnsimple.deprecate('`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.')
+
         response = client.get(Client.versioned("/%s/domains/%s/collaborators" % [account_id, domain_id]), Options::ListOptions.new(options))
 
         Dnsimple::PaginatedResponse.new(response, response["data"].map { |r| Struct::Collaborator.new(r) })
@@ -41,9 +44,12 @@ module Dnsimple
       # @option attributes [String] :email user email (mandatory)
       # @param  [Hash] options request options
       # @return [Dnsimple::PaginatedResponse<Dnsimple::Struct::Collaborator>]
+      # @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
       #
       # @raise  [Dnsimple::RequestError]
       def add_collaborator(account_id, domain_id, attributes, options = {})
+        Dnsimple.deprecate('`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.')
+
         Extra.validate_mandatory_attributes(attributes, [:email])
         response = client.post(Client.versioned("/%s/domains/%s/collaborators" % [account_id, domain_id]), attributes, options)
 
@@ -65,9 +71,12 @@ module Dnsimple
       # @param  [Hash] options request options
       # @return [Dnsimple::Response<nil>]
       #
+      # @deprecated `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
       # @raise  [Dnsimple::NotFoundError]
       # @raise  [Dnsimple::RequestError]
       def remove_collaborator(account_id, domain_id, contact_id, options = {})
+        Dnsimple.deprecate('`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.')
+
         response = client.delete(Client.versioned("/%s/domains/%s/collaborators/%s" % [account_id, domain_id, contact_id]), options)
 
         Dnsimple::Response.new(response, nil)


### PR DESCRIPTION
The changes to go out in the next version (9.0.1) are:

- NEW: Added `alias_email` and `destination_email` to `EmailForward`
- CHANGED: Deprecated `from` and `to` fields in `EmailForward`
- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231