### PR TITLE
Patch cycle - 2024 / Cycle 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - 'ruby-head'
           - 'truffleruby-head'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- CHANGED: Minimum Ruby version is now 3.2
+
 ## 9.0.1
 
 - NEW: Added `alias_email` and `destination_email` to `EmailForward`

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2024 DNSimple Corporation
+Copyright (c) 2010-2025 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We provide a full API and an easy-to-use web interface so you can get your domai
 
 ## Requirements
 
-- Ruby: MRI > 3.1+
+- Ruby: MRI > 3.2+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ puts response.data
 
 ## License
 
-Copyright (c) 2010-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2010-2025 DNSimple Corporation. This is Free Software distributed under the MIT license.


### PR DESCRIPTION
The changes to go out in the next version (10.0.0) are:

    CHANGED: Minimum Ruby version is now 3.2

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/296
Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/294