### PR TITLE
chore: Pin rubocop dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'coveralls', require: false
-gem 'rubocop', '1.75.4', require: false
-gem 'rubocop-performance', '1.25.0', require: false
-gem 'rubocop-rake', '0.7.1', require: false
-gem 'rubocop-rspec', '3.6.0', require: false
+gem "coveralls", "~> 0.8", require: false
+gem "rubocop", "~> 1.75", require: false
+gem "rubocop-performance", "~> 1.25", require: false
+gem "rubocop-rake", "~> 0.7", require: false
+gem "rubocop-rspec", "~> 3.6", require: false
 gem "base64", "~> 0.2.0"
 gem "bigdecimal", "~> 3.1"
 gem "csv", "~> 3.2"


### PR DESCRIPTION
It is a best practice to pin dependencies, even if development dependencies. In particular, Dependabot works better with pinned dependency instructions.