### PR TITLE
Add workflow for syncing test fixtures

### DIFF
--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -26,7 +26,7 @@ jobs:
           ls -al $TMP_DIR
           ls -al "$TMP_DIR/dnsimple-developer-main/"
           ls -al spec/fixtures.http/
-          rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/" spec/fixtures.http/
+          rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api" spec/fixtures.http/
           ls -al spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -1,0 +1,25 @@
+name: Sync test fixtures
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync_fixtures:
+    name: Sync test fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - name: Sync fixtures
+        run: |
+          TMP_DIR=$(mktemp -d)
+          curl -fsSL "https://codeload.github.com/dnsimple/dnsimple-developer/tar.gz/refs/heads/main" \
+            | tar -xz -C "$tmp"
+          rsync -a --delete "$TMP_DIR"/dnsimple-developer-*/fixtures/v2/ spec/fixtures.http/
+      - name: Run tests
+        run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           curl -fsSL "https://codeload.github.com/dnsimple/dnsimple-developer/tar.gz/refs/heads/main" \
-            | tar -xz -C "$tmp"
+            | tar -xz -C "$TMP_DIR"
           rsync -a --delete "$TMP_DIR"/dnsimple-developer-*/fixtures/v2/ spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -26,7 +26,7 @@ jobs:
           ls -al $TMP_DIR
           ls -al "$TMP_DIR/dnsimple-developer-main/"
           ls -al spec/fixtures.http/
-          rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api" spec/fixtures.http/
+          rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api/" spec/fixtures.http/
           ls -al spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -22,6 +22,11 @@ jobs:
           TMP_DIR=$(mktemp -d)
           curl -fsSL "https://codeload.github.com/dnsimple/dnsimple-developer/tar.gz/refs/heads/main" \
             | tar -xz -C "$TMP_DIR"
-          rsync -a --delete "$TMP_DIR"/dnsimple-developer-*/fixtures/v2/ spec/fixtures.http/
+          pwd
+          ls -al $TMP_DIR
+          ls -al "$TMP_DIR/dnsimple-developer-*/fixtures/v2/"
+          ls -al spec/fixtures.http/
+          rsync -a --delete "$TMP_DIR/dnsimple-developer-*/fixtures/v2/" spec/fixtures.http/
+          ls -al spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -38,7 +38,7 @@ jobs:
             git commit -m "chore: sync test fixtures as of $NOW"
             git push -u origin "$BRANCH"
 
-            cat > pr_body.md <<'MD'
+            cat <<'MD' > pr_body.md
             This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
 
             ## Checklist

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -1,6 +1,9 @@
 name: Sync test fixtures
 
 on:
+  push:
+    branches:
+      - "spike/pull-fixtures"
   workflow_dispatch:
 
 jobs:
@@ -34,9 +37,18 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "chore: sync test fixtures as of $NOW"
             git push -u origin "$BRANCH"
+
+            cat > pr_body.md <<'MD'
+            This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
+
+            ## Checklist
+            - [ ] Close and re-open this PR to trigger the CI workflow (it does not run automatically)
+            - [ ] Ensure the CI workflow passes before merging
+            MD
+
             gh pr create \
               --title "chore: Sync fixtures as of $NOW" \
-              --body "This PR replaces the fixtures in this repository with those from github.com/dnsimple/dnsimple-developer" \
+              --body-file pr_body.md \
               --base main \
               --head "$BRANCH"
           else

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -10,11 +10,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-          bundler-cache: true
       - name: Sync fixtures
         run: |
           TMP_DIR=$(mktemp -d)

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -49,7 +49,7 @@ jobs:
             git push -u origin "$BRANCH"
             gh pr create \
               --title "chore: Sync fixtures as of $NOW" \
-              --body "This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer" \
+              --body "This PR replaces the fixtures in this repository with those from dnsimple-developer" \
               --base main \
               --head "$BRANCH"
           else

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -21,6 +21,14 @@ jobs:
           rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api/" spec/fixtures.http/
       - name: Create a PR to sync fixtures if there are changes
         run: |
+          cat <<'MD' > pr_body.md
+          This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
+
+          ## Checklist
+          - [ ] Close and re-open this PR to trigger the CI workflow (it does not run automatically)
+          - [ ] Ensure the CI workflow passes before merging
+          MD
+
           # Configure Git identity for the workflow
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
@@ -37,14 +45,6 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "chore: sync test fixtures as of $NOW"
             git push -u origin "$BRANCH"
-
-            cat <<-'MD' > pr_body.md
-            This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
-
-            ## Checklist
-            - [ ] Close and re-open this PR to trigger the CI workflow (it does not run automatically)
-            - [ ] Ensure the CI workflow passes before merging
-            MD
 
             gh pr create \
               --title "chore: Sync fixtures as of $NOW" \

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -1,9 +1,6 @@
 name: Sync test fixtures
 
 on:
-  push:
-    branches:
-      - "spike/pull-fixtures"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-      - uses: actions/setup-gh@v4
       - name: Sync fixtures
         run: |
           TMP_DIR=$(mktemp -d)

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -1,7 +1,9 @@
 name: Sync test fixtures
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "spike/pull-fixtures"
 
 jobs:
   sync_fixtures:

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -24,9 +24,9 @@ jobs:
             | tar -xz -C "$TMP_DIR"
           pwd
           ls -al $TMP_DIR
-          ls -al "$TMP_DIR/dnsimple-developer-*/fixtures/v2/"
+          ls -al "$TMP_DIR/dnsimple-developer-main/"
           ls -al spec/fixtures.http/
-          rsync -a --delete "$TMP_DIR/dnsimple-developer-*/fixtures/v2/" spec/fixtures.http/
+          rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/" spec/fixtures.http/
           ls -al spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -30,3 +30,25 @@ jobs:
           ls -al spec/fixtures.http/
       - name: Run tests
         run: bundle exec rake
+      - name: Commit synced fixtures
+        run: |
+          # Configure Git identity for the workflow
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+          # Create and switch to a new branch
+          BRANCH="chore/sync-fixtures-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
+
+          # Stage changes
+          git add spec/fixtures.http
+
+          # Commit if there are staged changes
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: sync test fixtures"
+            git push -u origin "$BRANCH"
+          else
+            echo "No fixture changes to commit."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "spike/pull-fixtures"
+  workflow_dispatch:
 
 jobs:
   sync_fixtures:
@@ -17,6 +18,7 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
+      - uses: actions/setup-gh@v4
       - name: Sync fixtures
         run: |
           TMP_DIR=$(mktemp -d)
@@ -28,9 +30,7 @@ jobs:
           ls -al spec/fixtures.http/
           rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api/" spec/fixtures.http/
           ls -al spec/fixtures.http/
-      - name: Run tests
-        run: bundle exec rake
-      - name: Commit synced fixtures
+      - name: Create a PR to sync fixtures if there are changes
         run: |
           # Configure Git identity for the workflow
           git config --global user.name "github-actions"
@@ -38,6 +38,7 @@ jobs:
 
           # Create and switch to a new branch
           BRANCH="chore/sync-fixtures-${GITHUB_RUN_ID}"
+          NOW="$(date +'%Y-%m-%d %H:%M:%S')""
           git checkout -b "$BRANCH"
 
           # Stage changes
@@ -45,10 +46,15 @@ jobs:
 
           # Commit if there are staged changes
           if ! git diff --cached --quiet; then
-            git commit -m "chore: sync test fixtures"
+            git commit -m "chore: sync test fixtures as of $NOW"
             git push -u origin "$BRANCH"
+            gh pr create \
+              --title "chore: Sync fixtures as of $NOW" \
+              --body "This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer" \
+              --base main \
+              --head "$BRANCH"
           else
-            echo "No fixture changes to commit."
+            echo "No fixture detected; nothing to do"
           fi
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -37,7 +37,7 @@ jobs:
 
           # Create and switch to a new branch
           BRANCH="chore/sync-fixtures-${GITHUB_RUN_ID}"
-          NOW="$(date +'%Y-%m-%d %H:%M:%S')""
+          NOW="$(date +'%Y-%m-%d %H:%M:%S')"
           git checkout -b "$BRANCH"
 
           # Stage changes
@@ -49,7 +49,7 @@ jobs:
             git push -u origin "$BRANCH"
             gh pr create \
               --title "chore: Sync fixtures as of $NOW" \
-              --body "This PR replaces the fixtures in this repository with those from dnsimple-developer" \
+              --body "This PR replaces the fixtures in this repository with those from github.com/dnsimple/dnsimple-developer" \
               --base main \
               --head "$BRANCH"
           else

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -20,12 +20,7 @@ jobs:
           TMP_DIR=$(mktemp -d)
           curl -fsSL "https://codeload.github.com/dnsimple/dnsimple-developer/tar.gz/refs/heads/main" \
             | tar -xz -C "$TMP_DIR"
-          pwd
-          ls -al $TMP_DIR
-          ls -al "$TMP_DIR/dnsimple-developer-main/"
-          ls -al spec/fixtures.http/
           rsync -a --delete "$TMP_DIR/dnsimple-developer-main/fixtures/v2/api/" spec/fixtures.http/
-          ls -al spec/fixtures.http/
       - name: Create a PR to sync fixtures if there are changes
         run: |
           # Configure Git identity for the workflow

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -1,9 +1,6 @@
 name: Sync test fixtures
 
 on:
-  push:
-    branches:
-      - "spike/pull-fixtures"
   workflow_dispatch:
 
 jobs:
@@ -22,7 +19,7 @@ jobs:
       - name: Create a PR to sync fixtures if there are changes
         run: |
           cat <<'MD' > pr_body.md
-          This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
+          This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/
 
           ## Checklist
           - [ ] Close and re-open this PR to trigger the CI workflow (it does not run automatically)

--- a/.github/workflows/sync-test-fixtures.yml
+++ b/.github/workflows/sync-test-fixtures.yml
@@ -38,7 +38,7 @@ jobs:
             git commit -m "chore: sync test fixtures as of $NOW"
             git push -u origin "$BRANCH"
 
-            cat <<'MD' > pr_body.md
+            cat <<-'MD' > pr_body.md
             This PR replaces the fixtures in this repository with those from https://github.com/dnsimple/dnsimple-developer/"
 
             ## Checklist


### PR DESCRIPTION
Adds a workflow for syncing the fixtures in this repository with the ones from dnsimple-developer

This workflow currently has the following limitations:
- The workflow has to be manually triggered from Actions
- The automatically-created PR must be manually closed and reopened to trigger the CI workflow run. This is because the workflow currently opens PRs using the built-in `GITHUB_TOKEN` (See: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow)

Sample PR opened by this workflow: https://github.com/dnsimple/dnsimple-ruby/pull/425

<details><summary>I cross-checked the diff in the PR with a manual diff between dnsimple-developer and dnsimple-ruby</summary>

```
dnsimple-developer % diff -qr ./fixtures/v2/api ../dnsimple-ruby/spec/fixtures.http
Files ./fixtures/v2/api/accounts/success-user.http and ../dnsimple-ruby/spec/fixtures.http/accounts/success-user.http differ
Only in ../dnsimple-ruby/spec/fixtures.http: addCollaborator
Files ./fixtures/v2/api/checkRegistrantChange/error-domainnotfound.http and ../dnsimple-ruby/spec/fixtures.http/checkRegistrantChange/error-domainnotfound.http differ
Files ./fixtures/v2/api/checkRegistrantChange/success.http and ../dnsimple-ruby/spec/fixtures.http/checkRegistrantChange/success.http differ
Files ./fixtures/v2/api/createEmailForward/created.http and ../dnsimple-ruby/spec/fixtures.http/createEmailForward/created.http differ
Files ./fixtures/v2/api/createRegistrantChange/success.http and ../dnsimple-ruby/spec/fixtures.http/createRegistrantChange/success.http differ
Files ./fixtures/v2/api/createWebhook/created.http and ../dnsimple-ruby/spec/fixtures.http/createWebhook/created.http differ
Files ./fixtures/v2/api/deleteRegistrantChange/success.http and ../dnsimple-ruby/spec/fixtures.http/deleteRegistrantChange/success.http differ
Only in ./fixtures/v2/api/deleteRegistrantChange: success_async.http
Files ./fixtures/v2/api/dnsAnalytics/success.http and ../dnsimple-ruby/spec/fixtures.http/dnsAnalytics/success.http differ
Files ./fixtures/v2/api/getDomainPrices/failure.http and ../dnsimple-ruby/spec/fixtures.http/getDomainPrices/failure.http differ
Files ./fixtures/v2/api/getDomainPrices/success.http and ../dnsimple-ruby/spec/fixtures.http/getDomainPrices/success.http differ
Files ./fixtures/v2/api/getDomainRestore/success.http and ../dnsimple-ruby/spec/fixtures.http/getDomainRestore/success.http differ
Files ./fixtures/v2/api/getEmailForward/success.http and ../dnsimple-ruby/spec/fixtures.http/getEmailForward/success.http differ
Files ./fixtures/v2/api/getRegistrantChange/success.http and ../dnsimple-ruby/spec/fixtures.http/getRegistrantChange/success.http differ
Files ./fixtures/v2/api/getTld/success.http and ../dnsimple-ruby/spec/fixtures.http/getTld/success.http differ
Files ./fixtures/v2/api/getWebhook/success.http and ../dnsimple-ruby/spec/fixtures.http/getWebhook/success.http differ
Files ./fixtures/v2/api/listAccounts/success-user.http and ../dnsimple-ruby/spec/fixtures.http/listAccounts/success-user.http differ
Files ./fixtures/v2/api/listCharges/fail-400-bad-filter.http and ../dnsimple-ruby/spec/fixtures.http/listCharges/fail-400-bad-filter.http differ
Files ./fixtures/v2/api/listCharges/fail-403.http and ../dnsimple-ruby/spec/fixtures.http/listCharges/fail-403.http differ
Files ./fixtures/v2/api/listCharges/success.http and ../dnsimple-ruby/spec/fixtures.http/listCharges/success.http differ
Only in ../dnsimple-ruby/spec/fixtures.http: listCollaborators
Files ./fixtures/v2/api/listEmailForwards/success.http and ../dnsimple-ruby/spec/fixtures.http/listEmailForwards/success.http differ
Files ./fixtures/v2/api/listRegistrantChanges/success.http and ../dnsimple-ruby/spec/fixtures.http/listRegistrantChanges/success.http differ
Files ./fixtures/v2/api/listTlds/success.http and ../dnsimple-ruby/spec/fixtures.http/listTlds/success.http differ
Files ./fixtures/v2/api/listWebhooks/success.http and ../dnsimple-ruby/spec/fixtures.http/listWebhooks/success.http differ
Only in ../dnsimple-ruby/spec/fixtures.http: notfound-collaborator.http
Only in ./fixtures/v2/api: notfound-delegationSignerRecord.http
Only in ../dnsimple-ruby/spec/fixtures.http: notfound-delegationsignerrecord.http
Only in ./fixtures/v2/api/registerDomain: error-extended-attributes.http
Only in ../dnsimple-ruby/spec/fixtures.http: removeCollaborator
Files ./fixtures/v2/api/restoreDomain/success.http and ../dnsimple-ruby/spec/fixtures.http/restoreDomain/success.http differ
Only in ./fixtures/v2/api: updateZoneNsRecords
Files ./fixtures/v2/api/whoami/success-account.http and ../dnsimple-ruby/spec/fixtures.http/whoami/success-account.http differ
Files ./fixtures/v2/api/whoami/success.http and ../dnsimple-ruby/spec/fixtures.http/whoami/success.http differ
```
</details>

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/357