### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/lib/dnsimple/client/domains_email_forwards.rb
+++ b/lib/dnsimple/client/domains_email_forwards.rb
@@ -69,7 +69,7 @@ module Dnsimple
       #
       # @raise  [Dnsimple::RequestError]
       def create_email_forward(account_id, domain_id, attributes, options = {})
-        Extra.validate_mandatory_attributes(attributes, [:from, :to])
+        Extra.validate_mandatory_attributes(attributes, [:alias_name, :destination_email])
         response = client.post(Client.versioned("/%s/domains/%s/email_forwards" % [account_id, domain_id]), attributes, options)
 
         Dnsimple::Response.new(response, Struct::EmailForward.new(response["data"]))

--- a/lib/dnsimple/struct/email_forward.rb
+++ b/lib/dnsimple/struct/email_forward.rb
@@ -10,14 +10,6 @@ module Dnsimple
       # @return [Integer] The associated domain ID.
       attr_accessor :domain_id
 
-      # @return [String] The "local part" of the originating email address. Anything to the left of the @ symbol.
-      # @deprecated use {#alias_email} instead
-      attr_accessor :from
-
-      # @return [String] The full email address to forward to.
-      # @deprecated use {#destination_email} instead
-      attr_accessor :to
-
       # @return [String] The receiving email recipient.
       attr_accessor :alias_email
 

--- a/spec/dnsimple/client/domains_email_forwards_spec.rb
+++ b/spec/dnsimple/client/domains_email_forwards_spec.rb
@@ -100,7 +100,7 @@ describe Dnsimple::Client, ".domains" do
 
   describe "#create_email_forward" do
     let(:account_id) { 1010 }
-    let(:attributes) { { from: "jim", to: "jim@another.com" } }
+    let(:attributes) { { alias_name: "jim", destination_email: "jim@another.com" } }
     let(:domain_id) { "example.com" }
 
     before do
@@ -152,8 +152,6 @@ describe Dnsimple::Client, ".domains" do
       expect(result).to be_a(Dnsimple::Struct::EmailForward)
       expect(result.id).to eq(41872)
       expect(result.domain_id).to eq(235146)
-      expect(result.from).to eq("example@dnsimple.xyz")
-      expect(result.to).to eq("example@example.com")
       expect(result.alias_email).to eq("example@dnsimple.xyz")
       expect(result.destination_email).to eq("example@example.com")
       expect(result.created_at).to eq("2021-01-25T13:54:40Z")


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.