### PR TITLE
Support trustee service in transfers

### DIFF
--- a/lib/dnsimple/struct/domain_transfer.rb
+++ b/lib/dnsimple/struct/domain_transfer.rb
@@ -21,6 +21,9 @@ module Dnsimple
       # @return [Bool] True if the domain WHOIS privacy was requested.
       attr_accessor :whois_privacy
 
+      # @return [Bool] True if the domain Trustee service was requested.
+      attr_accessor :trustee_service
+
       # @return [String,nil] The reason if transfer failed.
       attr_accessor :status_description
 

--- a/test/dnsimple/client/registrar_test.rb
+++ b/test/dnsimple/client/registrar_test.rb
@@ -211,7 +211,7 @@ class RegistrarTest < Minitest::Test
     stub_request(:post, %r{/v2/#{@account_id}/registrar/domains/.+/transfers$})
         .to_return(read_http_fixture("transferDomain/success.http"))
 
-    attributes = { registrant_id: "10", auth_code: "x1y2z3" }
+    attributes = { registrant_id: "10", auth_code: "x1y2z3", trustee_service: true }
     @subject.transfer_domain(@account_id, domain_name = "example.com", attributes)
 
     assert_requested(:post, "https://api.dnsimple.test/v2/#{@account_id}/registrar/domains/#{domain_name}/transfers",
@@ -233,6 +233,7 @@ class RegistrarTest < Minitest::Test
     assert_kind_of(Dnsimple::Struct::DomainTransfer, result)
     assert_kind_of(Integer, result.id)
     assert_kind_of(Integer, result.domain_id)
+    refute(result.trustee_service)
   end
 
   test "transfer domain when attributes are incomplete raises argument error" do
@@ -288,6 +289,7 @@ class RegistrarTest < Minitest::Test
     assert_equal("cancelled", result.state)
     refute(result.auto_renew)
     refute(result.whois_privacy)
+    refute(result.trustee_service)
     assert_equal("Canceled by customer", result.status_description)
     assert_equal("2020-06-05T18:08:00Z", result.created_at)
     assert_equal("2020-06-05T18:10:01Z", result.updated_at)
@@ -321,6 +323,7 @@ class RegistrarTest < Minitest::Test
     assert_equal("transferring", result.state)
     refute(result.auto_renew)
     refute(result.whois_privacy)
+    refute(result.trustee_service)
     assert_nil(result.status_description)
     assert_equal("2020-06-05T18:08:00Z", result.created_at)
     assert_equal("2020-06-05T18:08:04Z", result.updated_at)


### PR DESCRIPTION
Updated lib/dnsimple/struct/domain_transfer.rb
  - Added attr_accessor :trustee_service to the DomainTransfer struct, so the field from the API response is parsed and accessible

Addresses https://github.com/dnsimple/dnsimple-app/issues/34667
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## :mag: QA

(Optional for reviewers)

✅ From the console (adjust `account_id`, `registrant_id`, `domain_name` and `base_url` accordingly) run `bundle exec ruby qa_transfer_trustee.rb`

```ruby
require 'json'
require 'dnsimple'

client = Dnsimple::Client.new(
  base_url: "http://api.dnsimple.localhost:3000",
  access_token: ENV.fetch("TOKEN")
)

account_id = 2
registrant_id = 27
domain_name = "example.com"

# Transfer a domain with trustee service enabled
attributes = { registrant_id: registrant_id, auth_code: "x1y2z3", trustee_service: true }
transfer = client.registrar.transfer_domain(account_id, domain_name, attributes).data
puts "transfer domain_id=#{transfer.domain_id} trustee_service=#{transfer.trustee_service}"

# Get the domain transfer to verify
transfer = client.registrar.get_domain_transfer(account_id, domain_name, transfer.id).data
puts "get transfer id=#{transfer.id} trustee_service=#{transfer.trustee_service}"
```

#### QA results

```
TLD .COM does not support trustee service (Dnsimple::RequestError)
```

```
lib/dnsimple/client.rb:173:in 'Dnsimple::Client#execute': Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code] (Dnsimple::RequestError)
```


## :clipboard: Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [ ] POST: Create a release version


## :shipit: Deployment Verification

- [ ] Verify release is created
