### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contact_id` attribute from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 12.3.0 - 2026-04-15
 
 ### Added

--- a/lib/dnsimple/struct/certificate.rb
+++ b/lib/dnsimple/struct/certificate.rb
@@ -9,9 +9,6 @@ module Dnsimple
       # @return [Integer] The associated domain ID.
       attr_accessor :domain_id
 
-      # @return [Integer] The associated contact ID.
-      attr_accessor :contact_id
-
       # @return [String] The certificate common name.
       attr_accessor :common_name
 

--- a/test/dnsimple/client/certificates_test.rb
+++ b/test/dnsimple/client/certificates_test.rb
@@ -134,7 +134,6 @@ class CertificatesTest < Minitest::Test
     assert_kind_of(Dnsimple::Struct::Certificate, result)
     assert_equal(101967, result.id)
     assert_equal(289333, result.domain_id)
-    assert_equal(2511, result.contact_id)
     assert_equal("www.bingo.pizza", result.common_name)
     assert_empty(result.alternate_names)
     assert_equal(1, result.years)


### PR DESCRIPTION
## Summary

Remove the deprecated `contact_id` attribute from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Existing tests updated to not reference `contact_id`
- [x] Tests pass